### PR TITLE
Fix for older FritzOS versions not showing any connections

### DIFF
--- a/custom_components/fritzbox_vpn/coordinator.py
+++ b/custom_components/fritzbox_vpn/coordinator.py
@@ -110,11 +110,18 @@ def _normalize_connection_uid(raw_uid: Any) -> Optional[str]:
 def _normalize_box_connections(box: Any) -> Dict[str, Any]:
     """API boxConnections (list or dict) → dict keyed by uid with normalized active."""
     result: Dict[str, Any] = {}
-    items = box if isinstance(box, list) else box.values() if isinstance(box, dict) else ()
-    for c in items:
-        if not isinstance(c, dict):
+    if isinstance(box, dict):
+        items_with_keys = box.items()
+    elif isinstance(box, list):
+        items_with_keys = [(None, c) for c in box]
+    else:
+        items_with_keys = ()
+    for dict_key, c in items_with_keys:
+        if not isinstance(c, dict):  
             continue
         raw_uid = c.get(API_KEY_UID)
+        if raw_uid is None and isinstance(dict_key, str):
+            raw_uid = dict_key
         uid = _normalize_connection_uid(raw_uid)
         if uid is None:
             continue


### PR DESCRIPTION
The Fritz!Box 4060 (Fritz!OS 8.02) returns boxConnections as a dict keyed by connection IDs (connection4, connection8, etc.), but individual connection objects don't contain a uid field. The integration's
   _normalize_box_connections() only iterated over dict values (discarding the keys) and then required a uid field inside each connection — so all connections were silently skipped.

  Fix in coordinator.py:110-126: Changed _normalize_box_connections to iterate over both dict keys and values. When a connection lacks a uid field, the dict key (e.g., connection4) is used as the fallback UID.

This was likely also the reason for https://github.com/rosch100/fritzbox-vpn/issues/16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPN connection data synchronization to handle multiple input formats from FritzBox devices. Enhanced processing ensures consistent identification of all connection types, reducing potential recognition issues and improving the reliability of VPN connection tracking and management within the integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->