### PR TITLE
Fix PyPI publish action version

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -50,7 +50,7 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v2
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: fritzboxvpn/dist
           print-hash: true


### PR DESCRIPTION
Use pypa/gh-action-pypi-publish@release/v1 — release/v2 does not exist.

Made with [Cursor](https://cursor.com)