### PR TITLE
Fix PyPI publish action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
       - "pyproject.toml"
       - ".pre-commit-config.yaml"
       - ".github/workflows/ci.yml"
+      - ".github/workflows/publish-pypi.yml"
       - ".github/rulesets/**"
       - ".github/instructions/**"
       - ".github/copilot-instructions.md"

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -50,7 +50,7 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v2
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: fritzboxvpn/dist
           print-hash: true

--- a/fritzboxvpn/README.md
+++ b/fritzboxvpn/README.md
@@ -2,4 +2,4 @@
 
 Async Python library for the AVM Fritz!Box Web UI API (WireGuard VPN connections).
 
-Used by the Home Assistant `fritzbox_vpn` integration.
+Used by the Home Assistant `fritzbox_vpn` integration (HACS and Core).


### PR DESCRIPTION
## Summary
- Use `pypa/gh-action-pypi-publish@release/v1` (release/v2 does not exist)
- Include `publish-pypi.yml` in CI path filters

## Test plan
- [x] CI (Ruff, pytest, HACS, hassfest)


Made with [Cursor](https://cursor.com)