### PR TITLE
fix: align SSDP helpers with Home Assistant fritz.ssdp_discovery

### DIFF
--- a/custom_components/fritzbox_vpn/config_flow.py
+++ b/custom_components/fritzbox_vpn/config_flow.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import ipaddress
 import logging
 from collections.abc import Mapping
 from typing import Any
@@ -55,6 +54,7 @@ from .fritz_config_source import get_existing_fritz_config
 from .ssdp_unique_id import (
     host_from_ssdp,
     is_fritzbox_router_discovery,
+    is_link_local_host,
     unique_id_for_discovery,
 )
 
@@ -163,13 +163,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="not_fritzbox")
 
         host = host_from_ssdp(discovery_info)
-        if not host:
+        if not host or is_link_local_host(host):
             return self.async_abort(reason="no_host")
-        try:
-            if ipaddress.ip_address(host).is_link_local:
-                return self.async_abort(reason="no_host")
-        except ValueError:
-            pass
 
         unique_id = unique_id_for_discovery(discovery_info, host)
         await self.async_set_unique_id(unique_id)

--- a/custom_components/fritzbox_vpn/ssdp_unique_id.py
+++ b/custom_components/fritzbox_vpn/ssdp_unique_id.py
@@ -1,11 +1,14 @@
-"""SSDP helpers (aligned with homeassistant/components/fritz/config_flow)."""
+"""SSDP helpers; keep host/UUID parsing in sync with homeassistant.components.fritz.ssdp_discovery."""
 
+import ipaddress
 from urllib.parse import urlparse
 from uuid import UUID
 
 from homeassistant.helpers.service_info.ssdp import ATTR_UPNP_UDN, SsdpServiceInfo
 
 from .const import FRITZBOX_SSDP_INDICATORS, REPEATER_INDICATORS
+
+FRITZ_BOX_HOST = "fritz.box"
 
 
 def parse_device_uuid(value: str) -> str | None:
@@ -20,50 +23,82 @@ def parse_device_uuid(value: str) -> str | None:
 
 
 def uuid_from_upnp_udn(raw_udn: str) -> str | None:
+    """Parse UPnP UDN (``uuid:<uuid>``)."""
     return parse_device_uuid(raw_udn.removeprefix("uuid:"))
 
 
 def uuid_from_ssdp_usn(usn: str) -> str | None:
+    """Parse device UUID from SSDP USN (``uuid:<uuid>::...``)."""
     if not usn.startswith("uuid:"):
         return None
-    return parse_device_uuid(usn.split("::", 1)[0].removeprefix("uuid:"))
+    return uuid_from_upnp_udn(usn.split("::", 1)[0])
+
+
+def hostname_from_url(url: str) -> str | None:
+    """Return hostname from a URL, or None if parsing fails."""
+    try:
+        return urlparse(url).hostname
+    except ValueError:
+        return None
 
 
 def uuid_from_discovery(discovery_info: SsdpServiceInfo) -> str | None:
     """Device UUID from UPnP UDN or SSDP USN."""
-    raw_udn = discovery_info.upnp.get(ATTR_UPNP_UDN)
-    if raw_udn and (device_uuid := uuid_from_upnp_udn(raw_udn)):
-        return device_uuid
-    if discovery_info.ssdp_usn and (
-        device_uuid := uuid_from_ssdp_usn(discovery_info.ssdp_usn)
-    ):
-        return device_uuid
+    if raw_udn := discovery_info.upnp.get(ATTR_UPNP_UDN):
+        if device_uuid := uuid_from_upnp_udn(raw_udn):
+            return device_uuid
+    if discovery_info.ssdp_usn:
+        if device_uuid := uuid_from_ssdp_usn(discovery_info.ssdp_usn):
+            return device_uuid
     return None
 
 
 def unique_id_for_discovery(discovery_info: SsdpServiceInfo, host: str) -> str:
-    """Stable config-flow unique_id: device UUID if present, else host."""
+    """Config-flow unique_id: device UUID if present, else host."""
     return uuid_from_discovery(discovery_info) or host
+
+
+def is_link_local_host(host: str) -> bool:
+    """Return True if host is a link-local IP address."""
+    try:
+        return ipaddress.ip_address(host).is_link_local
+    except ValueError:
+        return False
+
+
+def host_from_ssdp_usn(usn: str) -> str | None:
+    """Return fritz.box when embedded in a non-standard USN URL segment."""
+    search_start = 0
+    while (scheme_pos := usn.find("://", search_start)) != -1:
+        fragment_start = scheme_pos + 1
+        fragment_end = fragment_start
+        while fragment_end < len(usn) and usn[fragment_end] not in " \t\r\n":
+            if (
+                fragment_end > fragment_start
+                and usn[fragment_end : fragment_end + 2] == "::"
+            ):
+                break
+            fragment_end += 1
+        fragment = usn[fragment_start:fragment_end]
+        if hostname := hostname_from_url(f"http:{fragment}"):
+            if hostname.lower() == FRITZ_BOX_HOST:
+                return FRITZ_BOX_HOST
+        search_start = scheme_pos + 3
+    return None
 
 
 def host_from_ssdp(discovery_info: SsdpServiceInfo) -> str | None:
     """Host from SSDP location, headers, or USN."""
     if discovery_info.ssdp_location:
-        try:
-            if hostname := urlparse(discovery_info.ssdp_location).hostname:
-                return str(hostname)
-        except ValueError:
-            pass
+        if hostname := hostname_from_url(discovery_info.ssdp_location):
+            return hostname
     if discovery_info.ssdp_headers:
         location_header = discovery_info.ssdp_headers.get("location")
         if isinstance(location_header, str):
-            try:
-                if hostname := urlparse(location_header).hostname:
-                    return str(hostname)
-            except ValueError:
-                pass
-    if discovery_info.ssdp_usn and "fritz.box" in discovery_info.ssdp_usn.lower():
-        return "fritz.box"
+            if hostname := hostname_from_url(location_header):
+                return hostname
+    if discovery_info.ssdp_usn:
+        return host_from_ssdp_usn(discovery_info.ssdp_usn)
     return None
 
 
@@ -76,10 +111,12 @@ def is_fritzbox_router_discovery(discovery_info: SsdpServiceInfo) -> bool:
 
     combined = f"{st} {usn} {server} {location}".lower()
     if discovery_info.ssdp_headers:
-        headers_str = " ".join(
-            str(value) for value in discovery_info.ssdp_headers.values()
-        ).lower()
-        combined += f" {headers_str}"
+        combined += (
+            " "
+            + " ".join(
+                str(value) for value in discovery_info.ssdp_headers.values()
+            ).lower()
+        )
 
     if not any(indicator in combined for indicator in FRITZBOX_SSDP_INDICATORS):
         return False

--- a/custom_components/fritzbox_vpn/ssdp_unique_id.py
+++ b/custom_components/fritzbox_vpn/ssdp_unique_id.py
@@ -44,12 +44,14 @@ def hostname_from_url(url: str) -> str | None:
 
 def uuid_from_discovery(discovery_info: SsdpServiceInfo) -> str | None:
     """Device UUID from UPnP UDN or SSDP USN."""
-    if raw_udn := discovery_info.upnp.get(ATTR_UPNP_UDN):
-        if device_uuid := uuid_from_upnp_udn(raw_udn):
-            return device_uuid
-    if discovery_info.ssdp_usn:
-        if device_uuid := uuid_from_ssdp_usn(discovery_info.ssdp_usn):
-            return device_uuid
+    if (raw_udn := discovery_info.upnp.get(ATTR_UPNP_UDN)) and (
+        device_uuid := uuid_from_upnp_udn(raw_udn)
+    ):
+        return device_uuid
+    if discovery_info.ssdp_usn and (
+        device_uuid := uuid_from_ssdp_usn(discovery_info.ssdp_usn)
+    ):
+        return device_uuid
     return None
 
 
@@ -80,23 +82,26 @@ def host_from_ssdp_usn(usn: str) -> str | None:
                 break
             fragment_end += 1
         fragment = usn[fragment_start:fragment_end]
-        if hostname := hostname_from_url(f"http:{fragment}"):
-            if hostname.lower() == FRITZ_BOX_HOST:
-                return FRITZ_BOX_HOST
+        if (hostname := hostname_from_url(f"http:{fragment}")) and (
+            hostname.lower() == FRITZ_BOX_HOST
+        ):
+            return FRITZ_BOX_HOST
         search_start = scheme_pos + 3
     return None
 
 
 def host_from_ssdp(discovery_info: SsdpServiceInfo) -> str | None:
     """Host from SSDP location, headers, or USN."""
-    if discovery_info.ssdp_location:
-        if hostname := hostname_from_url(discovery_info.ssdp_location):
-            return hostname
+    if discovery_info.ssdp_location and (
+        hostname := hostname_from_url(discovery_info.ssdp_location)
+    ):
+        return hostname
     if discovery_info.ssdp_headers:
         location_header = discovery_info.ssdp_headers.get("location")
-        if isinstance(location_header, str):
-            if hostname := hostname_from_url(location_header):
-                return hostname
+        if isinstance(location_header, str) and (
+            hostname := hostname_from_url(location_header)
+        ):
+            return hostname
     if discovery_info.ssdp_usn:
         return host_from_ssdp_usn(discovery_info.ssdp_usn)
     return None

--- a/tests/test_ssdp_unique_id.py
+++ b/tests/test_ssdp_unique_id.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from custom_components.fritzbox_vpn.ssdp_unique_id import (
     host_from_ssdp,
+    host_from_ssdp_usn,
     is_fritzbox_router_discovery,
     parse_device_uuid,
     unique_id_for_discovery,
@@ -37,37 +38,45 @@ def _fritz_discovery(**kwargs: object) -> SsdpServiceInfo:
 
 
 def test_parse_device_uuid_accepts_valid_uuid() -> None:
+    """Test parse_device_uuid accepts a valid UUID string."""
     assert parse_device_uuid(MOCK_DEVICE_UUID) == MOCK_DEVICE_UUID
 
 
 def test_parse_device_uuid_rejects_invalid() -> None:
+    """Test parse_device_uuid rejects invalid values."""
     assert parse_device_uuid("not-a-uuid") is None
     assert parse_device_uuid("") is None
 
 
 def test_uuid_from_upnp_udn() -> None:
+    """Test uuid_from_upnp_udn parses UDN values."""
     assert uuid_from_upnp_udn(MOCK_UDN) == MOCK_DEVICE_UUID
     assert uuid_from_upnp_udn("uuid:not-a-uuid") is None
 
 
 def test_uuid_from_ssdp_usn() -> None:
+    """Test uuid_from_ssdp_usn parses USN values."""
     assert uuid_from_ssdp_usn(MOCK_USN) == MOCK_DEVICE_UUID
 
 
 def test_uuid_from_ssdp_usn_ignores_non_uuid_prefix() -> None:
+    """Test uuid_from_ssdp_usn ignores non-uuid USN prefixes."""
     assert uuid_from_ssdp_usn("mock_usn") is None
 
 
 def test_uuid_from_discovery_prefers_udn() -> None:
+    """Test uuid_from_discovery prefers UPnP UDN."""
     assert uuid_from_discovery(_fritz_discovery()) == MOCK_DEVICE_UUID
 
 
 def test_uuid_from_discovery_falls_back_to_usn() -> None:
+    """Test uuid_from_discovery falls back to SSDP USN."""
     discovery = _fritz_discovery(upnp={ATTR_UPNP_FRIENDLY_NAME: "FRITZ!Box 7530"})
     assert uuid_from_discovery(discovery) == MOCK_DEVICE_UUID
 
 
 def test_uuid_from_discovery_invalid_udn_uses_usn() -> None:
+    """Test uuid_from_discovery uses USN when UDN is invalid."""
     discovery = _fritz_discovery(
         upnp={ATTR_UPNP_FRIENDLY_NAME: "name", ATTR_UPNP_UDN: "uuid:not-a-uuid"},
     )
@@ -75,6 +84,7 @@ def test_uuid_from_discovery_invalid_udn_uses_usn() -> None:
 
 
 def test_unique_id_for_discovery_uses_host_without_uuid() -> None:
+    """Test unique_id_for_discovery uses host when no UUID is found."""
     discovery = _fritz_discovery(
         ssdp_usn="mock_usn",
         upnp={ATTR_UPNP_FRIENDLY_NAME: "name"},
@@ -83,10 +93,12 @@ def test_unique_id_for_discovery_uses_host_without_uuid() -> None:
 
 
 def test_host_from_ssdp_location() -> None:
+    """Test host_from_ssdp parses ssdp_location."""
     assert host_from_ssdp(_fritz_discovery()) == MOCK_HOST
 
 
 def test_host_from_ssdp_location_header() -> None:
+    """Test host_from_ssdp parses location from SSDP headers."""
     discovery = SsdpServiceInfo(
         ssdp_usn="mock_usn",
         ssdp_st="mock_st",
@@ -98,6 +110,7 @@ def test_host_from_ssdp_location_header() -> None:
 
 
 def test_host_from_ssdp_fritz_box_from_usn() -> None:
+    """Test host_from_ssdp extracts fritz.box from USN."""
     discovery = SsdpServiceInfo(
         ssdp_usn="uuid:device-1::upnp:rootdevice://fritz.box",
         ssdp_st="mock_st",
@@ -107,6 +120,7 @@ def test_host_from_ssdp_fritz_box_from_usn() -> None:
 
 
 def test_host_from_ssdp_skips_non_string_header_location() -> None:
+    """Test host_from_ssdp skips non-string location headers."""
     discovery = SsdpServiceInfo(
         ssdp_usn="mock_usn",
         ssdp_st="mock_st",
@@ -117,6 +131,7 @@ def test_host_from_ssdp_skips_non_string_header_location() -> None:
 
 
 def test_host_from_ssdp_empty_location_hostname_uses_headers() -> None:
+    """Test host_from_ssdp uses headers when location hostname is empty."""
     discovery = SsdpServiceInfo(
         ssdp_usn="mock_usn",
         ssdp_st="mock_st",
@@ -128,6 +143,7 @@ def test_host_from_ssdp_empty_location_hostname_uses_headers() -> None:
 
 
 def test_host_from_ssdp_returns_none_without_location() -> None:
+    """Test host_from_ssdp returns None without a location."""
     discovery = SsdpServiceInfo(
         ssdp_usn="mock_usn",
         ssdp_st="mock_st",
@@ -137,6 +153,7 @@ def test_host_from_ssdp_returns_none_without_location() -> None:
 
 
 def test_host_from_ssdp_header_value_error() -> None:
+    """Test host_from_ssdp handles urlparse ValueError."""
     discovery = SsdpServiceInfo(
         ssdp_usn="mock_usn",
         ssdp_st="mock_st",
@@ -150,11 +167,18 @@ def test_host_from_ssdp_header_value_error() -> None:
         assert host_from_ssdp(discovery) is None
 
 
+def test_host_from_ssdp_usn_rejects_false_positive_fritz_box_substring() -> None:
+    """Test USN host extraction does not match fritz.box inside other hostnames."""
+    assert host_from_ssdp_usn("uuid:device-1::vendor:my-fritz.box-repeater") is None
+
+
 def test_is_fritzbox_router_discovery_accepts_router() -> None:
+    """Test is_fritzbox_router_discovery accepts IGD routers."""
     assert is_fritzbox_router_discovery(_fritz_discovery()) is True
 
 
 def test_is_fritzbox_router_discovery_rejects_unknown_device() -> None:
+    """Test is_fritzbox_router_discovery rejects unknown devices."""
     discovery = SsdpServiceInfo(
         ssdp_st="urn:schemas-upnp-org:device:basic:1",
         ssdp_usn="uuid:other::device",
@@ -166,6 +190,7 @@ def test_is_fritzbox_router_discovery_rejects_unknown_device() -> None:
 
 
 def test_is_fritzbox_router_discovery_rejects_repeater() -> None:
+    """Test is_fritzbox_router_discovery rejects repeaters."""
     discovery = _fritz_discovery(
         ssdp_server="AVM UPnP/1.0 fritz!wlan repeater 310",
     )
@@ -173,6 +198,7 @@ def test_is_fritzbox_router_discovery_rejects_repeater() -> None:
 
 
 def test_is_fritzbox_router_discovery_fritzbox_without_igd() -> None:
+    """Test is_fritzbox_router_discovery accepts Fritz!Box without IGD ST."""
     discovery = _fritz_discovery(
         ssdp_st="urn:schemas-upnp-org:device:fritzbox:1",
         ssdp_server="AVM FRITZ!Box 7530",
@@ -181,6 +207,7 @@ def test_is_fritzbox_router_discovery_fritzbox_without_igd() -> None:
 
 
 def test_is_fritzbox_router_discovery_rejects_non_igd_non_fritzbox_name() -> None:
+    """Test is_fritzbox_router_discovery rejects non-router AVM devices."""
     discovery = SsdpServiceInfo(
         ssdp_st="urn:schemas-upnp-org:device:avm:1",
         ssdp_usn="uuid:x::device",
@@ -230,6 +257,7 @@ def test_host_from_ssdp_uses_valid_location_header() -> None:
 
 
 def test_is_fritzbox_router_discovery_includes_headers() -> None:
+    """Test is_fritzbox_router_discovery inspects SSDP headers."""
     discovery = SsdpServiceInfo(
         ssdp_st="urn:schemas-upnp-org:device:InternetGatewayDevice:1",
         ssdp_usn=MOCK_USN,


### PR DESCRIPTION
## Summary
- Sync `ssdp_unique_id.py` with Home Assistant Core `fritz.ssdp_discovery` (PR #165042): strict `fritz.box` USN parsing, shared URL hostname helper, link-local host rejection.
- Use `is_link_local_host` in SSDP config flow instead of inline `ipaddress` handling.
- Extend SSDP unit tests (false-positive USN substring, docstrings).

## Test plan
- [x] `pytest tests/test_ssdp_unique_id.py tests/test_config_flow_ssdp.py` (33 passed)
- [x] `pytest tests/` (150 passed)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced device discovery to consistently handle missing or invalid network addresses
* Improved error handling for host extraction during network detection

## Tests
* Expanded test coverage for device discovery edge cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rosch100/fritzbox-vpn/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->