### PR TITLE
chore: release 1.2.1

### DIFF
--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -16,5 +16,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.0"
+  "version": "1.2.1"
 }


### PR DESCRIPTION
Bump manifest version for HACS release v1.2.1.

Made with [Cursor](https://cursor.com)