### PR TITLE
fix: migrate Fritz VPN session adapter

### DIFF
--- a/custom_components/fritzbox_vpn/coordinator.py
+++ b/custom_components/fritzbox_vpn/coordinator.py
@@ -10,12 +10,10 @@ from fritzboxvpn import (
     API_KEY_ACTIVE,
     API_KEY_CONNECTED,
     API_KEY_NAME,
-    FritzBoxVPNSession,
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -35,6 +33,7 @@ from .const import (
     UPDATE_INTERVAL_MIN,
     host_from_config,
 )
+from .fritzconnection_session import FritzConnectionVPNSession
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -102,11 +101,12 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
             name=DOMAIN,
             update_interval=timedelta(seconds=update_interval_seconds),
         )
-        self.fritz_session = FritzBoxVPNSession(
-            async_get_clientsession(hass),
+        self.fritz_session = FritzConnectionVPNSession(
+            hass,
             host_from_config(config),
             config[CONF_USERNAME],
             config[CONF_PASSWORD],
+            use_tls=True,
         )
         self.config = config
         self.entry_id = entry_id

--- a/custom_components/fritzbox_vpn/flow_forms.py
+++ b/custom_components/fritzbox_vpn/flow_forms.py
@@ -210,7 +210,7 @@ def set_validation_error(
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate Fritz!Box connectivity; VPN connections are discovered at setup."""
-    # Validate via Fritz!Box Web UI REST WireGuard endpoints using FritzConnection.
+    # Validate via Fritz!Box HTTP API (AHA-HTTP Interface) WireGuard endpoints using FritzConnection.
     # This adapter is synchronous underneath and runs blocking calls in the executor.
     session = FritzConnectionVPNSession(
         hass,

--- a/custom_components/fritzbox_vpn/flow_forms.py
+++ b/custom_components/fritzbox_vpn/flow_forms.py
@@ -210,8 +210,8 @@ def set_validation_error(
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate Fritz!Box connectivity; VPN connections are discovered at setup."""
-    # Validate via Fritz!Box WebUI REST WireGuard endpoints using FritzConnection.
-    # Note: this adapter is sync under the hood and uses executor jobs.
+    # Validate via Fritz!Box Web UI REST WireGuard endpoints using FritzConnection.
+    # This adapter is synchronous underneath and runs blocking calls in the executor.
     session = FritzConnectionVPNSession(
         hass,
         data[CONF_HOST],

--- a/custom_components/fritzbox_vpn/flow_forms.py
+++ b/custom_components/fritzbox_vpn/flow_forms.py
@@ -8,11 +8,9 @@ from collections.abc import Mapping
 from typing import Any
 
 import voluptuous as vol
-from fritzboxvpn import FritzBoxVPNSession
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     CONF_UPDATE_INTERVAL,
@@ -30,6 +28,7 @@ from .const import (
     password_from_sources,
 )
 from .coordinator import normalize_update_interval
+from .fritzconnection_session import FritzConnectionVPNSession
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -211,15 +210,18 @@ def set_validation_error(
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate Fritz!Box connectivity; VPN connections are discovered at setup."""
-    session = FritzBoxVPNSession(
-        async_get_clientsession(hass),
+    # Validate via Fritz!Box WebUI REST WireGuard endpoints using FritzConnection.
+    # Note: this adapter is sync under the hood and uses executor jobs.
+    session = FritzConnectionVPNSession(
+        hass,
         data[CONF_HOST],
         data[CONF_USERNAME],
         password_from_sources(data),
+        use_tls=True,
     )
 
     try:
-        await session.async_get_session()
+        await session.async_get_vpn_connections()
         await session.async_close()
         return {"title": f"{INTEGRATION_TITLE} ({data[CONF_HOST]})"}
     except Exception as err:

--- a/custom_components/fritzbox_vpn/flow_forms.py
+++ b/custom_components/fritzbox_vpn/flow_forms.py
@@ -210,7 +210,7 @@ def set_validation_error(
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate Fritz!Box connectivity; VPN connections are discovered at setup."""
-    # Validate via Fritz!Box HTTP API (AHA-HTTP Interface) WireGuard endpoints using FritzConnection.
+    # Validate via Fritz!Box HTTP API WireGuard endpoints using FritzConnection.
     # This adapter is synchronous underneath and runs blocking calls in the executor.
     session = FritzConnectionVPNSession(
         hass,

--- a/custom_components/fritzbox_vpn/fritzconnection_session.py
+++ b/custom_components/fritzbox_vpn/fritzconnection_session.py
@@ -1,4 +1,4 @@
-"""Adapter: FritzConnection-based session for FritzBox VPN Web UI REST API."""
+"""Adapter: FritzConnection-based session for FritzBox VPN HTTP API endpoints."""
 
 from __future__ import annotations
 

--- a/custom_components/fritzbox_vpn/fritzconnection_session.py
+++ b/custom_components/fritzbox_vpn/fritzconnection_session.py
@@ -1,4 +1,4 @@
-"""Adapter: FritzConnection-based session for FritzBox VPN WebUI REST API."""
+"""Adapter: FritzConnection-based session for FritzBox VPN Web UI REST API."""
 
 from __future__ import annotations
 

--- a/custom_components/fritzbox_vpn/fritzconnection_session.py
+++ b/custom_components/fritzbox_vpn/fritzconnection_session.py
@@ -1,0 +1,147 @@
+"""Adapter: FritzConnection-based session for FritzBox VPN WebUI REST API."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import Timeout as RequestsTimeout
+
+_LOGGER = logging.getLogger(__name__)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from fritzconnection import FritzConnection
+    from fritzconnection.lib.fritzwireguard import FritzWireguard
+
+
+class FritzConnectionVPNSession:
+    """Async wrapper for FritzConnection (sync) WireGuard calls.
+
+    The integration expects these methods:
+    - async_get_vpn_connections() -> dict[connection_uid, connection_payload]
+    - async_toggle_vpn(connection_uid, enable) -> bool
+    - async_close()
+    """
+
+    def __init__(
+        self,
+        hass: Any,
+        host: str,
+        username: str,
+        password: str,
+        *,
+        use_tls: bool = True,
+    ) -> None:
+        self._hass = hass
+        self._host = host
+        self._username = username
+        self._password = password
+        self._use_tls = use_tls
+
+        self._fc: FritzConnection | None = None  # type: ignore[name-defined]
+        self._fwg: FritzWireguard | None = None  # type: ignore[name-defined]
+
+    def _ensure_client(self) -> None:
+        if self._fc is not None and self._fwg is not None:
+            return
+
+        # Import lazily so unit tests can run even when `fritzconnection`
+        # is not installed in the fritzbox-vpn test venv.
+        from fritzconnection import FritzConnection  # type: ignore
+        from fritzconnection.lib.fritzwireguard import FritzWireguard  # type: ignore
+
+        self._fc = FritzConnection(
+            address=self._host,
+            user=self._username or None,
+            password=self._password,
+            use_tls=self._use_tls,
+        )
+        self._fwg = FritzWireguard(fc=self._fc)
+
+    @staticmethod
+    def _is_fritz_authorization_error(err: Exception) -> bool:
+        # Import lazily to avoid hard dependency at import time.
+        try:
+            from fritzconnection.core.exceptions import (
+                FritzAuthorizationError,  # type: ignore
+            )
+        except Exception:
+            return err.__class__.__name__ == "FritzAuthorizationError"
+        return isinstance(err, FritzAuthorizationError)
+
+    def _close_sync(self) -> None:
+        if self._fc is None:
+            return
+        # requests.Session.close() is safe and synchronous
+        self._fc.session.close()
+        self._fc = None
+        self._fwg = None
+
+    def _get_vpn_connections_sync(self) -> dict[str, Any]:
+        self._ensure_client()
+        assert self._fwg is not None
+        return self._fwg.get_vpn_connections()
+
+    def _toggle_vpn_sync(self, connection_uid: str, enable: bool) -> bool:
+        self._ensure_client()
+        assert self._fwg is not None
+        return self._fwg.toggle_vpn(connection_uid, enable)
+
+    async def async_close(self) -> None:
+        await self._hass.async_add_executor_job(self._close_sync)
+
+    async def async_get_vpn_connections(self) -> dict[str, Any]:
+        """Fetch latest VPN connections with HTTPS->HTTP fallback."""
+        try:
+            return await self._hass.async_add_executor_job(
+                self._get_vpn_connections_sync
+            )
+        except RequestsTimeout as err:
+            raise TimeoutError(str(err)) from err
+        except RequestsConnectionError as err:
+            if self._use_tls:
+                _LOGGER.warning(
+                    "HTTPS connection failed; falling back to HTTP for host %s: %s",
+                    self._host,
+                    err,
+                )
+                self._use_tls = False
+                await self._hass.async_add_executor_job(self._close_sync)
+                return await self._hass.async_add_executor_job(
+                    self._get_vpn_connections_sync
+                )
+            raise ConnectionError(f"failed to get login page: {err}") from err
+        except Exception as err:
+            if self._is_fritz_authorization_error(err):
+                # Coordinator maps auth-indicators by substring matching.
+                raise ValueError(f"Invalid SID: {err}") from err
+            raise
+
+    async def async_toggle_vpn(self, connection_uid: str, enable: bool) -> bool:
+        """Toggle VPN on/off with HTTPS->HTTP fallback and auth propagation."""
+        try:
+            return await self._hass.async_add_executor_job(
+                self._toggle_vpn_sync, connection_uid, enable
+            )
+        except RequestsTimeout as err:
+            raise TimeoutError(str(err)) from err
+        except RequestsConnectionError as err:
+            if self._use_tls:
+                _LOGGER.warning(
+                    "HTTPS connection failed; falling back to HTTP for host %s: %s",
+                    self._host,
+                    err,
+                )
+                self._use_tls = False
+                await self._hass.async_add_executor_job(self._close_sync)
+                return await self._hass.async_add_executor_job(
+                    self._toggle_vpn_sync, connection_uid, enable
+                )
+            raise ConnectionError(f"failed to toggle VPN: {err}") from err
+        except Exception as err:
+            if self._is_fritz_authorization_error(err):
+                # Coordinator may schedule reauth on auth errors.
+                raise ConnectionError(f"invalid sid: {err}") from err
+            raise
+

--- a/custom_components/fritzbox_vpn/translations/en.json
+++ b/custom_components/fritzbox_vpn/translations/en.json
@@ -34,7 +34,7 @@
     },
     "error": {
       "cannot_connect": "Failed to connect to FritzBox. Please check the IP address and network connection.",
-      "invalid_auth": "Authentication failed. Please check username and password. If credentials are correct, enable TR-064 (Permit access for apps) in the FritzBox under Home Network > Network > Network settings > Access Settings in the Home Network. Note: UPnP is only needed for automatic discovery, not for API access.",
+      "invalid_auth": "Authentication failed. Please check username and password. If credentials are correct, enable TR-064 (Permit access for apps) in the FritzBox under Home Network > Network > Network settings > Access Settings in the Home Network. UPnP is only needed for automatic discovery, not for API access.",
       "invalid_host": "Invalid host. Please enter a valid IP address or hostname.",
       "unknown": "An unexpected error occurred. Please check the Home Assistant logs for details. Make sure TR-064 (Permit access for apps) is enabled in the FritzBox.",
       "config_entry_not_found": "Config entry not found. Please add the integration again."

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -149,13 +149,13 @@ async def test_reauth_updates_credentials(hass: HomeAssistant, mock_config_entry
 async def test_validate_input_maps_auth_error(hass: HomeAssistant) -> None:
     """validate_input raises InvalidAuth on login failure."""
     session_mock = AsyncMock()
-    session_mock.async_get_session = AsyncMock(
+    session_mock.async_get_vpn_connections = AsyncMock(
         side_effect=ValueError("Login failed: Invalid SID")
     )
     session_mock.async_close = AsyncMock()
 
     with patch(
-        "custom_components.fritzbox_vpn.flow_forms.FritzBoxVPNSession",
+        "custom_components.fritzbox_vpn.flow_forms.FritzConnectionVPNSession",
         return_value=session_mock,
     ):
         with pytest.raises(InvalidAuth):
@@ -275,13 +275,13 @@ async def test_reauth_shows_error_on_validation_failure(
 async def test_validate_input_maps_connect_error(hass: HomeAssistant) -> None:
     """validate_input raises CannotConnect on connection errors."""
     session_mock = AsyncMock()
-    session_mock.async_get_session = AsyncMock(
+    session_mock.async_get_vpn_connections = AsyncMock(
         side_effect=ConnectionError("Failed to get login page")
     )
     session_mock.async_close = AsyncMock()
 
     with patch(
-        "custom_components.fritzbox_vpn.flow_forms.FritzBoxVPNSession",
+        "custom_components.fritzbox_vpn.flow_forms.FritzConnectionVPNSession",
         return_value=session_mock,
     ):
         with pytest.raises(CannotConnect):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,5 +1,6 @@
 """Tests for FritzBox VPN coordinator and session helpers."""
 
+import inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -108,6 +109,14 @@ async def test_schedule_reauth_only_once(hass: HomeAssistant) -> None:
         coordinator._schedule_reauth()
 
     hass.async_create_task.assert_called_once()
+
+    # When `async_create_task` is mocked, the coroutine argument would
+    # otherwise be left un-awaited and raise a "never awaited" warning.
+    called_args, _called_kwargs = hass.async_create_task.call_args
+    if called_args:
+        coro = called_args[0]
+        if inspect.iscoroutine(coro):
+            coro.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_flow_forms.py
+++ b/tests/test_flow_forms.py
@@ -112,11 +112,11 @@ def test_set_validation_error_branches() -> None:
 async def test_validate_input_success(hass: HomeAssistant) -> None:
     """validate_input returns title when session login succeeds."""
     session_mock = AsyncMock()
-    session_mock.async_get_session = AsyncMock(return_value="sid")
+    session_mock.async_get_vpn_connections = AsyncMock(return_value={"x": {}})
     session_mock.async_close = AsyncMock()
 
     with patch(
-        "custom_components.fritzbox_vpn.flow_forms.FritzBoxVPNSession",
+        "custom_components.fritzbox_vpn.flow_forms.FritzConnectionVPNSession",
         return_value=session_mock,
     ):
         info = await validate_input(


### PR DESCRIPTION
Migrate the FritzBox VPN session adapter to the FritzConnection-based wrapper and update coordinator/flow form tests accordingly.