### PR TITLE
ci: skip PyPI publish for beta tags

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -24,7 +24,11 @@ permissions:
 jobs:
   publish:
     name: PyPI
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.confirm == 'publish'
+    # Best practice: Only publish when the underlying PyPI package version changes.
+    # Beta/pre-release tags (e.g. v1.2.2b1) may not bump the library version, so
+    # uploading would fail with "File already exists".
+    if: (github.event_name != 'workflow_dispatch' || github.event.inputs.confirm == 'publish')
+      && (github.event_name != 'push' || (!contains(github.ref_name, 'beta') && !contains(github.ref_name, 'b')))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: pypi


### PR DESCRIPTION
Best practice: avoid uploading the PyPI library package for beta/pre-release tags when the library version might not change. Skip publish-pypi job when ref_name contains 'beta' or the prerelease marker 'b' (e.g. v1.2.2b1).