### PR TITLE
Chore/release 1.2.2b2

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -24,7 +24,11 @@ permissions:
 jobs:
   publish:
     name: PyPI
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.confirm == 'publish'
+    # Best practice: Only publish when the underlying PyPI package version changes.
+    # Beta/pre-release tags (e.g. v1.2.2b1) may not bump the library version, so
+    # uploading would fail with "File already exists".
+    if: (github.event_name != 'workflow_dispatch' || github.event.inputs.confirm == 'publish')
+      && (github.event_name != 'push' || (!contains(github.ref_name, 'beta') && !contains(github.ref_name, 'b')))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: pypi

--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -16,5 +16,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.1"
+  "version": "1.2.2b2"
 }


### PR DESCRIPTION
## Summary

<!-- Kurz: Was ändert sich und warum? -->

## Test plan

- [ ] CI grün (`Ruff`, `pytest`, `HACS validate`, `hassfest`) bzw. lokal: `ruff check` + `pytest tests/ --cov -q`
- [ ] Bei SSDP/`config_flow`: `tests/test_ssdp_unique_id.py` und `tests/test_config_flow_ssdp.py`
- [ ] Bei Manifest/Strings: HACS- und hassfest-Workflow beachtet

## Checklist

- [ ] Copilot Code Review abgewartet (läuft automatisch bei Push)
- [ ] Keine Secrets oder Zugangsdaten im Diff
- [ ] SSDP-Helfer nur in `ssdp_unique_id.py` (keine Duplikate in `config_flow`)
- [ ] Version in `manifest.json` nur bei Release-relevanten Änderungen angepasst
