### PR TITLE
Release 1.2.2b5: HA-compliant entities, reconfigure flow, breaking switch entity ID

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,7 +33,7 @@ Flag as blocking when you see:
 - Repeater discovery enabled or repeater-specific flows added by mistake
 - Dummy defaults for failed API/SSDP instead of explicit errors
 - New code without tests for `config_flow` / SSDP changes
-- Breaking changes to `manifest.json` version without release notes context
+- Breaking changes to `manifest.json` version without release notes in `docs/releases/v{version}.md` (used by `.github/workflows/release.yml` for HACS/HA update dialog)
 
 Prefer suggestions over nits for line length in legacy files (Ruff ignores `E501`).
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 # Release- und Beta-Release-Workflow für HACS
 # - Tag v*.*.* (z. B. v0.9.0) → normales Release
 # - Tag v*.*.*b* oder v*.*.*-beta.* (z. B. v0.9.0b1) → Pre-Release (Beta)
+# - Release-Text: docs/releases/v{version}.md (sonst GitHub auto-generate)
 
 name: Release
 
@@ -37,10 +38,21 @@ jobs:
             exit 1
           fi
 
-      - uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          prerelease: ${{ contains(github.ref_name, 'b') || contains(github.ref_name, 'beta') }}
-          name: Release ${{ github.ref_name }}
+      - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          NOTES_FILE="docs/releases/${TAG}.md"
+          ARGS=( "$TAG" --title "Release ${TAG}" )
+          if [[ "$TAG" == *b* || "$TAG" == *beta* ]]; then
+            ARGS+=( --prerelease )
+          fi
+          if [ -f "$NOTES_FILE" ]; then
+            echo "Using release notes from $NOTES_FILE"
+            ARGS+=( --notes-file "$NOTES_FILE" )
+          else
+            echo "No release notes at $NOTES_FILE; using auto-generated notes"
+            ARGS+=( --generate-notes )
+          fi
+          gh release create "${ARGS[@]}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent-Anleitung (fritzbox-vpn)
 
-Home-Assistant-Custom-Integration für WireGuard-VPN auf AVM Fritz!Box.
+Kurzreferenz für **Coding-Agents** (Cursor, Copilot): projektspezifische Invarianten und lokale Checks. Nutzer-Doku: `README.md`. Review-Hinweise: `.github/copilot-instructions.md`.
 
 ## Architektur
 
@@ -10,20 +10,19 @@ Home-Assistant-Custom-Integration für WireGuard-VPN auf AVM Fritz!Box.
 | SSDP / `unique_id` (SSOT) | `ssdp_unique_id.py` |
 | Config Flow | `config_flow.py` |
 | Daten / Polling | `coordinator.py`, `sensor.py`, `switch.py` |
-| Tests | `tests/` (pytest + `pytest-homeassistant-custom-component`) |
+| Tests | `tests/` |
 
-## Wichtige Regeln
+## Invarianten
 
-- **SSDP-Logik nur in `ssdp_unique_id.py`:** UUID aus UDN/USN, Host aus Location, `unique_id_for_discovery`, Router vs. Repeater (`is_fritzbox_router_discovery`). Nicht in `config_flow` duplizieren.
-- **Repeater:** Diese Integration discovert nur **Router**, keine FRITZ!Repeater (anders als `homeassistant.components.fritz` im Core).
-- **Keine stillen Fallbacks:** Fehlende Discovery-Daten explizit behandeln (Abort/Fehler), keine Dummy-`unique_id`.
-- **Home Assistant:** Mindestversion in `hacs.json` und `manifest.json` (2026.1.0); Tests: `scripts/requirements-test.txt`.
+- SSDP/`unique_id` nur in `ssdp_unique_id.py` — nicht in `config_flow.py` duplizieren.
+- Nur Fritz!Box-**Router** discovern, keine FRITZ!Repeater.
+- Keine stillen Fallbacks: fehlende Discovery-Daten → Abort/Fehler, keine Dummy-`unique_id`.
+- Breaking Changes: Release Notes in `docs/releases/v{version}.md` (Workflow `release.yml`, HACS/HA-Update-Dialog).
+- Mindestversion HA: `hacs.json` / `manifest.json`.
 
-## Quality Scale
+## Qualität & Tests
 
-Ziel: **Gold** (siehe `custom_components/fritzbox_vpn/quality_scale.yaml`): Reauth, Diagnostics, Übersetzungen, **≥85 % Test-Coverage** (`pytest --cov`). Offizielles Badge erst nach Aufnahme in Home Assistant Core.
-
-## Tests lokal
+Ziel **Gold** (`custom_components/fritzbox_vpn/quality_scale.yaml`), Coverage ≥ 85 %.
 
 ```bash
 python3 -m venv .venv
@@ -32,39 +31,8 @@ python3 -m venv .venv
 .venv/bin/pytest tests/ --cov=custom_components/fritzbox_vpn -q
 ```
 
-`tests/conftest.py` setzt `hass_config_dir` auf das Repo-Root und aktiviert Custom Integrations.
+Vor Merge: CI-Jobs `Ruff`, `pytest`, `HACS validate`, `hassfest`.
 
-## GitHub Copilot Code Review
+## Core-Vorbereitung
 
-- **Automatisch:** Ruleset „Copilot code review“ (alle Branches, Review bei jedem Push).
-- **Konfiguration:** `.github/rulesets/copilot-code-review.json`, Richtlinien in `.github/copilot-instructions.md` und `.github/instructions/*.instructions.md`.
-- **Settings:** Repository → Copilot → Code review → Custom Instructions aktiviert lassen.
-
-## CI / Automation (Übersicht)
-
-| Workflow | Trigger | Zweck |
-|----------|---------|--------|
-| **ci.yml** | PR/Push (Pfade), nightly, manual | Ruff, pytest, HACS, hassfest |
-| **actionlint.yml** | `.github/**` | Workflow-Syntax |
-| **dependency-review.yml** | PR (Deps) | Sicherheit Abhängigkeiten (fail high+) |
-| **release.yml** | Tags `v*` | GitHub Release + Manifest-Versionscheck |
-| **stale.yml** | täglich | Inaktive Issues/PRs |
-| **Dependabot** | wöchentlich | Actions + pip |
-| **CodeQL** | Default Setup (GitHub) | Python + Actions, kein `codeql.yml` (Konflikt) |
-
-PR-Checks heißen: `Ruff`, `pytest`, `HACS validate`, `hassfest`.
-
-**Geschütztes `main`:** Ruleset „Required CI checks“ – Änderungen nur per **Pull Request**; vor Merge müssen `Ruff`, `pytest`, `HACS validate`, `hassfest` grün sein.
-
-## Core-Integration
-
-Vorbereitet unter `home-assistant-core/homeassistant/components/fritzbox_vpn/`:
-
-- API in PyPI-Library **`fritzboxvpn`** (`fritzboxvpn/` im Repo, vor Core-Merge auf PyPI veröffentlichen)
-- `runtime_data` statt `hass.data` für Coordinator/known_uids
-- `quality_scale: gold`, Brand über `homeassistant/brands/fritzbox.json`
-- Core-Tests unter `tests/components/fritzbox_vpn/`
-
-Vor dem Core-PR: `fritzboxvpn==1.0.0` auf PyPI publizieren (Workflow `.github/workflows/publish-pypi.yml`, Setup `docs/pypi-publish.md`), Doku-PR aus `docs/home-assistant-io/fritzbox_vpn.markdown`.
-
-Stabile SSDP-`unique_id` für FRITZ! (inkl. Repeater) liegt in `home-assistant/core` PR #165042. Bei SSDP-Änderungen Konzept mit Core abstimmen; Router/Repeater-Filter nur hier.
+API-Library `fritzboxvpn/` (PyPI vor Core-Merge), Core-Pfad unter `home-assistant-core/homeassistant/components/fritzbox_vpn/`. Details: `docs/pypi-publish.md`, `docs/home-assistant-io/fritzbox_vpn.markdown`.

--- a/README.de.md
+++ b/README.de.md
@@ -36,6 +36,10 @@ Um eine Beta-Version zu installieren (z. B. zum Testen von Fixes vor der näch
 
 Beta-Releases erscheinen als GitHub-Vorabversionen (Tags wie `v0.10.0b1`).
 
+### Version 1.2.2b5 (Beta)
+
+**Breaking Change:** Die VPN-Switch-Entität ist jetzt die Hauptfunktion des Verbindungs-Geräts (`has_entity_name` / `_attr_name = None`). Der Anzeigename entspricht nur noch dem VPN-Namen (z. B. „Office VPN“ statt „Office VPN VPN“). Die **Entity-ID** ändert sich von `switch.<vpn_name>_vpn` auf `switch.<vpn_name>` (z. B. `switch.office_vpn_vpn` → `switch.office_vpn`). Automatisierungen und Dashboards mit der alten Entity-ID müssen angepasst werden; `unique_id` bleibt unverändert.
+
 ## Konfiguration
 
 **Wichtig:** TR-064 ist immer für API-Zugriffe erforderlich (siehe Abschnitt Voraussetzungen). Für die automatische Erkennung sollte UPnP in deiner FritzBox aktiviert sein (empfohlen, aber nicht erforderlich). Wenn UPnP deaktiviert ist, kannst du die Integration weiterhin manuell konfigurieren.

--- a/README.de.md
+++ b/README.de.md
@@ -36,10 +36,6 @@ Um eine Beta-Version zu installieren (z. B. zum Testen von Fixes vor der näch
 
 Beta-Releases erscheinen als GitHub-Vorabversionen (Tags wie `v0.10.0b1`).
 
-### Version 1.2.2b5 (Beta)
-
-**Breaking Change:** Die VPN-Switch-Entität ist jetzt die Hauptfunktion des Verbindungs-Geräts (`has_entity_name` / `_attr_name = None`). Der Anzeigename entspricht nur noch dem VPN-Namen (z. B. „Office VPN“ statt „Office VPN VPN“). Die **Entity-ID** ändert sich von `switch.<vpn_name>_vpn` auf `switch.<vpn_name>` (z. B. `switch.office_vpn_vpn` → `switch.office_vpn`). Automatisierungen und Dashboards mit der alten Entity-ID müssen angepasst werden; `unique_id` bleibt unverändert.
-
 ## Konfiguration
 
 **Wichtig:** TR-064 ist immer für API-Zugriffe erforderlich (siehe Abschnitt Voraussetzungen). Für die automatische Erkennung sollte UPnP in deiner FritzBox aktiviert sein (empfohlen, aber nicht erforderlich). Wenn UPnP deaktiviert ist, kannst du die Integration weiterhin manuell konfigurieren.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ To install a beta release (e.g. for testing fixes before the next stable release
 
 Beta releases are published as GitHub Pre-releases (tags like `v0.10.0b1`).
 
+### Version 1.2.2b5 (Beta)
+
+**Breaking change:** The VPN switch is now the device's main feature (`has_entity_name` / `_attr_name = None`). The display name is the VPN connection name only (e.g. "Office VPN" instead of "Office VPN VPN"). The **entity ID** changes from `switch.<vpn_name>_vpn` to `switch.<vpn_name>` (e.g. `switch.office_vpn_vpn` → `switch.office_vpn`). Update automations and dashboards that reference the old entity ID; `unique_id` is unchanged.
+
 ## Configuration
 
 **Important:** TR-064 is always required for API access (see Requirements section). For automatic discovery to work, UPnP should be enabled in your FritzBox (recommended, but not required). If UPnP is disabled, you can still configure the integration manually.

--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@ To install a beta release (e.g. for testing fixes before the next stable release
 
 Beta releases are published as GitHub Pre-releases (tags like `v0.10.0b1`).
 
-### Version 1.2.2b5 (Beta)
-
-**Breaking change:** The VPN switch is now the device's main feature (`has_entity_name` / `_attr_name = None`). The display name is the VPN connection name only (e.g. "Office VPN" instead of "Office VPN VPN"). The **entity ID** changes from `switch.<vpn_name>_vpn` to `switch.<vpn_name>` (e.g. `switch.office_vpn_vpn` → `switch.office_vpn`). Update automations and dashboards that reference the old entity ID; `unique_id` is unchanged.
-
 ## Configuration
 
 **Important:** TR-064 is always required for API access (see Requirements section). For automatic discovery to work, UPnP should be enabled in your FritzBox (recommended, but not required). If UPnP is disabled, you can still configure the integration manually.

--- a/custom_components/fritzbox_vpn/__init__.py
+++ b/custom_components/fritzbox_vpn/__init__.py
@@ -28,7 +28,7 @@ from .entity_registry import (
     get_orphaned_entity_entries,
     remove_orphaned_entities,
     remove_unexpected_entity_entries,
-    repair_entity_id_suffixes,
+    repair_entity_ids,
 )
 from .models import FritzboxVpnConfigEntry, FritzboxVpnRuntimeData
 
@@ -88,13 +88,13 @@ async def _async_remove_unavailable_entities(
 async def _async_repair_entity_id_suffixes(
     hass: HomeAssistant, call: ServiceCall
 ) -> None:
-    """Repair entity IDs with _2, _3, … suffix: remove stale base entry and rename to base ID."""
+    """Repair legacy and suffixed entity IDs, then reload when anything changed."""
     for entry_id in _entry_ids_for_cleanup_service(hass, call):
-        count, _ = repair_entity_id_suffixes(hass, entry_id)
+        count, _ = repair_entity_ids(hass, entry_id)
         if count:
             await hass.config_entries.async_reload(entry_id)
             _LOGGER.info(
-                "Repair entity ID suffixes: repaired %d entities for entry %s",
+                "Repair entity IDs: repaired %d entities for entry %s",
                 count,
                 entry_id,
             )
@@ -170,12 +170,12 @@ def _cleanup_empty_connection_devices(hass: HomeAssistant, entry_id: str) -> int
     return removed
 
 
-def _repair_suffixes_before_platform_setup(hass: HomeAssistant, entry_id: str) -> int:
-    """Repair entity-id suffixes before platform setup."""
-    repaired_count, _ = repair_entity_id_suffixes(hass, entry_id)
+def _repair_entity_ids_before_platform_setup(hass: HomeAssistant, entry_id: str) -> int:
+    """Repair entity IDs before platform setup."""
+    repaired_count, _ = repair_entity_ids(hass, entry_id)
     if repaired_count:
         _LOGGER.info(
-            "Repaired %d entity ID suffix(es) before platform setup",
+            "Repaired %d entity ID(s) before platform setup",
             repaired_count,
         )
     return repaired_count
@@ -256,7 +256,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: FritzboxVpnConfigEntry) 
         "Created parent device: %s (ID: %s)", parent_device.name, parent_device.id
     )
 
-    _repair_suffixes_before_platform_setup(hass, entry.entry_id)
+    _repair_entity_ids_before_platform_setup(hass, entry.entry_id)
 
     try:
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/fritzbox_vpn/__init__.py
+++ b/custom_components/fritzbox_vpn/__init__.py
@@ -224,15 +224,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: FritzboxVpnConfigEntry) 
     entry.runtime_data = FritzboxVpnRuntimeData(coordinator=coordinator)
 
     if coordinator.data:
-        removed_shadow_entities = remove_unexpected_entity_entries(
-            hass,
-            entry.entry_id,
-            current_uids=set(coordinator.data.keys()),
-        )
-        if removed_shadow_entities:
-            _LOGGER.info(
-                "Removed %d shadow entity registry entries during setup",
-                removed_shadow_entities,
+        try:
+            removed_shadow_entities = remove_unexpected_entity_entries(
+                hass,
+                entry.entry_id,
+                current_uids=set(coordinator.data.keys()),
+            )
+            if removed_shadow_entities:
+                _LOGGER.info(
+                    "Removed %d shadow entity registry entries during setup",
+                    removed_shadow_entities,
+                )
+        except Exception as err:
+            # Best-effort cleanup: do not let registry cleanup bugs fail setup.
+            _LOGGER.warning(
+                "Shadow entity cleanup failed during setup for entry %s: %s",
+                entry.entry_id,
+                err,
             )
 
     device_registry = dr.async_get(hass)

--- a/custom_components/fritzbox_vpn/__init__.py
+++ b/custom_components/fritzbox_vpn/__init__.py
@@ -28,7 +28,9 @@ from .entity_registry import (
     get_orphaned_entity_entries,
     remove_orphaned_entities,
     remove_unexpected_entity_entries,
+    repair_entity_id_suffixes,
     repair_entity_ids,
+    repair_legacy_entity_object_ids,
 )
 from .models import FritzboxVpnConfigEntry, FritzboxVpnRuntimeData
 
@@ -171,14 +173,28 @@ def _cleanup_empty_connection_devices(hass: HomeAssistant, entry_id: str) -> int
 
 
 def _repair_entity_ids_before_platform_setup(hass: HomeAssistant, entry_id: str) -> int:
-    """Repair entity IDs before platform setup."""
-    repaired_count, _ = repair_entity_ids(hass, entry_id)
+    """Repair numeric entity_id suffixes (_2, _3, …) before platform setup."""
+    repaired_count, _ = repair_entity_id_suffixes(hass, entry_id)
     if repaired_count:
         _LOGGER.info(
-            "Repaired %d entity ID(s) before platform setup",
+            "Repaired %d numeric entity ID suffix(es) before platform setup",
             repaired_count,
         )
     return repaired_count
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: FritzboxVpnConfigEntry) -> bool:
+    """Run one-time migrations for config entries."""
+    if entry.version < 2:
+        count, _ = repair_legacy_entity_object_ids(hass, entry.entry_id)
+        if count:
+            _LOGGER.info(
+                "Migrated %d legacy entity ID(s) for config entry %s",
+                count,
+                entry.entry_id,
+            )
+        hass.config_entries.async_update_entry(entry, version=2)
+    return True
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/custom_components/fritzbox_vpn/__init__.py
+++ b/custom_components/fritzbox_vpn/__init__.py
@@ -27,6 +27,7 @@ from .coordinator import FritzBoxVPNCoordinator
 from .entity_registry import (
     get_orphaned_entity_entries,
     remove_orphaned_entities,
+    remove_unexpected_entity_entries,
     repair_entity_id_suffixes,
 )
 from .models import FritzboxVpnConfigEntry, FritzboxVpnRuntimeData
@@ -221,6 +222,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: FritzboxVpnConfigEntry) 
         ) from err
 
     entry.runtime_data = FritzboxVpnRuntimeData(coordinator=coordinator)
+
+    if coordinator.data:
+        removed_shadow_entities = remove_unexpected_entity_entries(
+            hass,
+            entry.entry_id,
+            current_uids=set(coordinator.data.keys()),
+        )
+        if removed_shadow_entities:
+            _LOGGER.info(
+                "Removed %d shadow entity registry entries during setup",
+                removed_shadow_entities,
+            )
 
     device_registry = dr.async_get(hass)
     parent_device = device_registry.async_get_or_create(

--- a/custom_components/fritzbox_vpn/binary_sensor.py
+++ b/custom_components/fritzbox_vpn/binary_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import UNIQUE_ID_SUFFIX_CONNECTED
 from .coordinator import FritzBoxVPNCoordinator
-from .entity import FritzBoxVPNEntity, setup_vpn_platform
+from .entity import FritzBoxVPNEntity, setup_vpn_platform, vpn_entities_for_uids
 from .models import FritzboxVpnConfigEntry
 
 PARALLEL_UPDATES = 1
@@ -28,15 +28,9 @@ async def async_setup_entry(
     def _create_entities(
         coordinator: FritzBoxVPNCoordinator, uids: set[str]
     ) -> list[FritzBoxVPNConnectedBinarySensor]:
-        if not coordinator.data:
-            return []
-        return [
-            FritzBoxVPNConnectedBinarySensor(
-                coordinator, entry, uid, coordinator.data[uid]
-            )
-            for uid in uids
-            if uid in coordinator.data
-        ]
+        return vpn_entities_for_uids(
+            coordinator, entry, uids, FritzBoxVPNConnectedBinarySensor
+        )
 
     await setup_vpn_platform(
         entry,
@@ -62,9 +56,8 @@ class FritzBoxVPNConnectedBinarySensor(FritzBoxVPNEntity, BinarySensorEntity):
             connection_uid,
             connection_data,
             unique_id_suffix=UNIQUE_ID_SUFFIX_CONNECTED,
+            translation_key="connected",
         )
-        self._attr_translation_key = "connected"
-        self._attr_object_id_suffix = UNIQUE_ID_SUFFIX_CONNECTED
         self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
 
     @property

--- a/custom_components/fritzbox_vpn/binary_sensor.py
+++ b/custom_components/fritzbox_vpn/binary_sensor.py
@@ -63,7 +63,6 @@ class FritzBoxVPNConnectedBinarySensor(FritzBoxVPNEntity, BinarySensorEntity):
             connection_data,
             unique_id_suffix=UNIQUE_ID_SUFFIX_CONNECTED,
         )
-        self._attr_name = "Connected"
         self._attr_translation_key = "connected"
         self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
 

--- a/custom_components/fritzbox_vpn/binary_sensor.py
+++ b/custom_components/fritzbox_vpn/binary_sensor.py
@@ -63,6 +63,7 @@ class FritzBoxVPNConnectedBinarySensor(FritzBoxVPNEntity, BinarySensorEntity):
             connection_data,
             unique_id_suffix=UNIQUE_ID_SUFFIX_CONNECTED,
         )
+        self._attr_name = "Connected"
         self._attr_translation_key = "connected"
         self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
 

--- a/custom_components/fritzbox_vpn/binary_sensor.py
+++ b/custom_components/fritzbox_vpn/binary_sensor.py
@@ -64,6 +64,7 @@ class FritzBoxVPNConnectedBinarySensor(FritzBoxVPNEntity, BinarySensorEntity):
             unique_id_suffix=UNIQUE_ID_SUFFIX_CONNECTED,
         )
         self._attr_translation_key = "connected"
+        self._attr_object_id_suffix = UNIQUE_ID_SUFFIX_CONNECTED
         self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
 
     @property

--- a/custom_components/fritzbox_vpn/config_flow.py
+++ b/custom_components/fritzbox_vpn/config_flow.py
@@ -294,7 +294,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reconfigure",
-            data_schema=flow_forms.configure_schema(user_input, entry_options),
+            data_schema=flow_forms.configure_schema_for_resubmit(user_input),
             errors=errors,
         )
 
@@ -499,6 +499,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         return self.async_show_form(
             step_id="configure",
-            data_schema=flow_forms.configure_schema(user_input, entry_options),
+            data_schema=flow_forms.configure_schema_for_resubmit(user_input),
             errors=errors,
         )

--- a/custom_components/fritzbox_vpn/config_flow.py
+++ b/custom_components/fritzbox_vpn/config_flow.py
@@ -87,7 +87,7 @@ async def _try_create_entry_from_credentials(
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for FritzBox VPN."""
 
-    VERSION = 1
+    VERSION = 2
 
     def __init__(self) -> None:
         self._discovered_host: str | None = None

--- a/custom_components/fritzbox_vpn/config_flow.py
+++ b/custom_components/fritzbox_vpn/config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import selector
 from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
 from .const import (
@@ -60,9 +61,15 @@ from .ssdp_unique_id import (
 
 _LOGGER = logging.getLogger(__name__)
 
-OPTIONS_LABEL_CONFIGURE = "Configure (host, user, update interval)"
-OPTIONS_LABEL_CLEANUP = "Remove unavailable entities"
-OPTIONS_LABEL_REPAIR_ENTITY_IDS = "Repair entity IDs"
+def _options_action_selector(available_actions: list[str]) -> selector.SelectSelector:
+    """Options-flow action selector with translated labels."""
+    return selector.SelectSelector(
+        selector.SelectSelectorConfig(
+            options=available_actions,
+            translation_key="options_action",
+            mode=selector.SelectSelectorMode.LIST,
+        )
+    )
 
 
 async def _try_create_entry_from_credentials(
@@ -261,6 +268,63 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Reconfigure host, credentials, and update interval without re-adding."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reconfigure",
+                data_schema=configure_schema(
+                    reconfigure_entry.data or {},
+                    reconfigure_entry.options or {},
+                ),
+                errors=errors,
+            )
+
+        user_input = dict(user_input)
+        fill_password_if_missing(user_input, reconfigure_entry.data or {})
+        if not validate_host_on_submit(user_input, errors):
+            return self.async_show_form(
+                step_id="reconfigure",
+                data_schema=configure_schema(
+                    user_input, reconfigure_entry.options or {}
+                ),
+                errors=errors,
+            )
+        try:
+            await validate_input(self.hass, user_input)
+        except Exception as err:
+            set_validation_error(errors, err, log_unknown_details=True)
+        else:
+            config_data = {
+                CONF_HOST: user_input[CONF_HOST],
+                CONF_USERNAME: user_input[CONF_USERNAME],
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+            }
+            options_data = {
+                CONF_UPDATE_INTERVAL: normalize_update_interval(
+                    user_input.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+                )
+            }
+            return self.async_update_reload_and_abort(
+                reconfigure_entry,
+                data=config_data,
+                options=options_data,
+                reason="reconfigure_successful",
+            )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=configure_schema(
+                user_input, reconfigure_entry.options or {}
+            ),
+            errors=errors,
+        )
+
     @staticmethod
     @callback
     def async_get_options_flow(
@@ -317,18 +381,18 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 return await self.async_step_repair_entity_ids_confirm()
             return await self.async_step_configure()
 
-        choices = {OPTIONS_ACTION_CONFIGURE: OPTIONS_LABEL_CONFIGURE}
+        available_actions = [OPTIONS_ACTION_CONFIGURE]
         if has_cleanup_action:
-            choices[OPTIONS_ACTION_CLEANUP] = OPTIONS_LABEL_CLEANUP
+            available_actions.append(OPTIONS_ACTION_CLEANUP)
         if has_repair_action:
-            choices[OPTIONS_ACTION_REPAIR_ENTITY_IDS] = OPTIONS_LABEL_REPAIR_ENTITY_IDS
+            available_actions.append(OPTIONS_ACTION_REPAIR_ENTITY_IDS)
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Required("action", default=OPTIONS_ACTION_CONFIGURE): vol.In(
-                        choices
-                    ),
+                    vol.Required(
+                        "action", default=OPTIONS_ACTION_CONFIGURE
+                    ): _options_action_selector(available_actions),
                 }
             ),
         )

--- a/custom_components/fritzbox_vpn/config_flow.py
+++ b/custom_components/fritzbox_vpn/config_flow.py
@@ -15,10 +15,9 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import selector
 from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
+from . import flow_forms
 from .const import (
-    CONF_UPDATE_INTERVAL,
     DEFAULT_HOST,
-    DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
     ERROR_KEY_CANNOT_CONNECT,
     ERROR_KEY_CONFIG_ENTRY_NOT_FOUND,
@@ -30,27 +29,13 @@ from .const import (
     host_from_config,
     password_from_sources,
 )
-from .coordinator import normalize_update_interval
 from .entity_registry import (
     get_entity_id_suffix_repairs,
     get_orphaned_entity_entries,
     remove_orphaned_entities,
     repair_entity_id_suffixes,
 )
-from .flow_forms import (
-    CannotConnect,
-    InvalidAuth,
-    configure_schema,
-    confirm_checkbox_schema,
-    confirm_schema,
-    credentials_defaults,
-    credentials_schema,
-    fill_password_if_missing,
-    reauth_schema,
-    set_validation_error,
-    validate_host_on_submit,
-    validate_input,
-)
+from .flow_forms import CannotConnect, InvalidAuth
 from .fritz_config_source import get_existing_fritz_config
 from .ssdp_unique_id import (
     host_from_ssdp,
@@ -60,6 +45,7 @@ from .ssdp_unique_id import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
 
 def _options_action_selector(available_actions: list[str]) -> selector.SelectSelector:
     """Options-flow action selector with translated labels."""
@@ -83,13 +69,13 @@ async def _try_create_entry_from_credentials(
     log_unknown_details: bool,
 ) -> FlowResult | None:
     """Validate credentials and create entry; None if the form should be shown again."""
-    fill_password_if_missing(user_input, *password_sources)
-    if not validate_host_on_submit(user_input, errors):
+    flow_forms.fill_password_if_missing(user_input, *password_sources)
+    if not flow_forms.validate_host_on_submit(user_input, errors):
         return None
     try:
-        info = await validate_input(hass, user_input)
+        info = await flow_forms.validate_input(hass, user_input)
     except Exception as err:
-        set_validation_error(errors, err, log_unknown_details=log_unknown_details)
+        flow_forms.set_validation_error(errors, err, log_unknown_details=log_unknown_details)
         return None
     if unique_id is not None:
         await flow.async_set_unique_id(unique_id)
@@ -120,7 +106,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 has_password = bool(password_from_sources(self._existing_config))
                 if has_host and has_username and has_password:
                     try:
-                        info = await validate_input(self.hass, self._existing_config)
+                        info = await flow_forms.validate_input(self.hass, self._existing_config)
                         return self.async_create_entry(
                             title=info["title"], data=self._existing_config
                         )
@@ -141,7 +127,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             "Autoconfiguration connection test failed: %s", err
                         )
                         errors["base"] = ERROR_KEY_UNKNOWN
-            schema = credentials_schema(*credentials_defaults(self._existing_config))
+            schema = flow_forms.credentials_schema(
+                *flow_forms.credentials_defaults(self._existing_config)
+            )
             return self.async_show_form(
                 step_id="user", data_schema=schema, errors=errors
             )
@@ -157,7 +145,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
         if result is not None:
             return result
-        schema = credentials_schema(*credentials_defaults(user_input))
+        schema = flow_forms.credentials_schema(*flow_forms.credentials_defaults(user_input))
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
 
     async def async_step_ssdp(self, discovery_info: SsdpServiceInfo) -> FlowResult:
@@ -191,7 +179,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is None:
             return self.async_show_form(
                 step_id="confirm",
-                data_schema=confirm_schema(
+                data_schema=flow_forms.confirm_schema(
                     self._existing_config, self._discovered_host
                 ),
                 description_placeholders={
@@ -212,7 +200,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return result
         return self.async_show_form(
             step_id="confirm",
-            data_schema=confirm_schema(
+            data_schema=flow_forms.confirm_schema(
                 self._existing_config,
                 self._discovered_host,
                 current_input=user_input,
@@ -236,7 +224,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is None:
             return self.async_show_form(
                 step_id="reauth_confirm",
-                data_schema=reauth_schema(username_default),
+                data_schema=flow_forms.reauth_schema(username_default),
                 description_placeholders={"host": host},
                 errors=errors,
             )
@@ -247,9 +235,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_PASSWORD: user_input[CONF_PASSWORD],
         }
         try:
-            await validate_input(self.hass, credentials)
+            await flow_forms.validate_input(self.hass, credentials)
         except Exception as err:
-            set_validation_error(errors, err, log_unknown_details=True)
+            flow_forms.set_validation_error(errors, err, log_unknown_details=True)
         else:
             return self.async_update_reload_and_abort(
                 reauth_entry,
@@ -263,7 +251,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reauth_confirm",
-            data_schema=reauth_schema(user_input.get(CONF_USERNAME, username_default)),
+            data_schema=flow_forms.reauth_schema(user_input.get(CONF_USERNAME, username_default)),
             description_placeholders={"host": host},
             errors=errors,
         )
@@ -274,42 +262,28 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Reconfigure host, credentials, and update interval without re-adding."""
         reconfigure_entry = self._get_reconfigure_entry()
         errors: dict[str, str] = {}
+        entry_options = reconfigure_entry.options or {}
 
         if user_input is None:
             return self.async_show_form(
                 step_id="reconfigure",
-                data_schema=configure_schema(
+                data_schema=flow_forms.configure_schema(
                     reconfigure_entry.data or {},
-                    reconfigure_entry.options or {},
+                    entry_options,
                 ),
                 errors=errors,
             )
 
         user_input = dict(user_input)
-        fill_password_if_missing(user_input, reconfigure_entry.data or {})
-        if not validate_host_on_submit(user_input, errors):
-            return self.async_show_form(
-                step_id="reconfigure",
-                data_schema=configure_schema(
-                    user_input, reconfigure_entry.options or {}
-                ),
-                errors=errors,
+        if await flow_forms.async_validate_configure_input(
+            self.hass,
+            user_input,
+            errors,
+            reconfigure_entry.data or {},
+        ):
+            config_data, options_data = flow_forms.config_and_options_from_configure_input(
+                user_input
             )
-        try:
-            await validate_input(self.hass, user_input)
-        except Exception as err:
-            set_validation_error(errors, err, log_unknown_details=True)
-        else:
-            config_data = {
-                CONF_HOST: user_input[CONF_HOST],
-                CONF_USERNAME: user_input[CONF_USERNAME],
-                CONF_PASSWORD: user_input[CONF_PASSWORD],
-            }
-            options_data = {
-                CONF_UPDATE_INTERVAL: normalize_update_interval(
-                    user_input.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
-                )
-            }
             return self.async_update_reload_and_abort(
                 reconfigure_entry,
                 data=config_data,
@@ -319,9 +293,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reconfigure",
-            data_schema=configure_schema(
-                user_input, reconfigure_entry.options or {}
-            ),
+            data_schema=flow_forms.configure_schema(user_input, entry_options),
             errors=errors,
         )
 
@@ -420,7 +392,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         return self.async_show_form(
             step_id=step_id,
-            data_schema=confirm_checkbox_schema(),
+            data_schema=flow_forms.confirm_checkbox_schema(),
         )
 
     async def async_step_cleanup_confirm(
@@ -483,45 +455,40 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if not config_entry:
             return self.async_abort(reason=ERROR_KEY_CONFIG_ENTRY_NOT_FOUND)
 
-        if user_input is not None:
-            user_input = dict(user_input)
-            user_input.pop("action", None)
-            fill_password_if_missing(user_input, config_entry.data or {})
-            if not validate_host_on_submit(user_input, errors):
-                return self.async_show_form(
-                    step_id="configure",
-                    data_schema=configure_schema(
-                        user_input, config_entry.options or {}
-                    ),
-                    errors=errors,
-                )
-            try:
-                await validate_input(self.hass, user_input)
-            except Exception as err:
-                set_validation_error(errors, err, log_unknown_details=True)
-            else:
-                config_data = {
-                    CONF_HOST: user_input[CONF_HOST],
-                    CONF_USERNAME: user_input[CONF_USERNAME],
-                    CONF_PASSWORD: user_input[CONF_PASSWORD],
-                }
-                update_interval = normalize_update_interval(
-                    user_input.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
-                )
-                options_data = {CONF_UPDATE_INTERVAL: update_interval}
-                self.hass.config_entries.async_update_entry(
-                    config_entry,
-                    data=config_data,
-                    options=options_data,
-                )
-                result = self.async_create_entry(title="", data=options_data)
-                await self.hass.config_entries.async_reload(config_entry.entry_id)
-                return result
+        entry_options = config_entry.options or {}
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="configure",
+                data_schema=flow_forms.configure_schema(
+                    config_entry.data or {},
+                    entry_options,
+                ),
+                errors=errors,
+            )
+
+        user_input = dict(user_input)
+        user_input.pop("action", None)
+        if await flow_forms.async_validate_configure_input(
+            self.hass,
+            user_input,
+            errors,
+            config_entry.data or {},
+        ):
+            config_data, options_data = flow_forms.config_and_options_from_configure_input(
+                user_input
+            )
+            self.hass.config_entries.async_update_entry(
+                config_entry,
+                data=config_data,
+                options=options_data,
+            )
+            result = self.async_create_entry(title="", data=options_data)
+            await self.hass.config_entries.async_reload(config_entry.entry_id)
+            return result
 
         return self.async_show_form(
             step_id="configure",
-            data_schema=configure_schema(
-                config_entry.data or {}, config_entry.options or {}
-            ),
+            data_schema=flow_forms.configure_schema(user_input, entry_options),
             errors=errors,
         )

--- a/custom_components/fritzbox_vpn/config_flow.py
+++ b/custom_components/fritzbox_vpn/config_flow.py
@@ -31,9 +31,10 @@ from .const import (
 )
 from .entity_registry import (
     get_entity_id_suffix_repairs,
+    get_legacy_entity_object_id_repairs,
     get_orphaned_entity_entries,
     remove_orphaned_entities,
-    repair_entity_id_suffixes,
+    repair_entity_ids,
 )
 from .flow_forms import CannotConnect, InvalidAuth
 from .fritz_config_source import get_existing_fritz_config
@@ -322,12 +323,19 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 self.hass, self._config_entry.entry_id
             )
             registry = er.async_get(self.hass)
-            repairs = get_entity_id_suffix_repairs(
+            legacy_repairs = get_legacy_entity_object_id_repairs(
+                self.hass, self._config_entry.entry_id
+            )
+            suffix_repairs = get_entity_id_suffix_repairs(
                 registry, self._config_entry.entry_id
             )
             has_cleanup_action = error_key is None and bool(to_remove)
-            has_repair_action = bool(repairs)
-            return (has_cleanup_action, has_repair_action, len(repairs))
+            has_repair_action = bool(legacy_repairs) or bool(suffix_repairs)
+            return (
+                has_cleanup_action,
+                has_repair_action,
+                len(legacy_repairs) + len(suffix_repairs),
+            )
         except Exception as err:
             _LOGGER.exception(
                 "Failed to evaluate available options actions for entry %s: %s",
@@ -426,16 +434,18 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_repair_entity_ids_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Confirm repair of entity IDs (_2, _3, … → base ID)."""
+        """Confirm repair of entity IDs (legacy suffixes and _2, _3, …)."""
         config_entry = self._get_current_entry()
         if not config_entry:
             return self.async_abort(reason=ERROR_KEY_CONFIG_ENTRY_NOT_FOUND)
         entry_id = config_entry.entry_id
         registry = er.async_get(self.hass)
-        repairs = get_entity_id_suffix_repairs(registry, entry_id)
+        legacy_repairs = get_legacy_entity_object_id_repairs(self.hass, entry_id)
+        suffix_repairs = get_entity_id_suffix_repairs(registry, entry_id)
+        pending = [*legacy_repairs, *suffix_repairs]
 
         async def on_repair(confirmed_entry_id: str) -> None:
-            count, _ = repair_entity_id_suffixes(self.hass, confirmed_entry_id)
+            count, _ = repair_entity_ids(self.hass, confirmed_entry_id)
             if count:
                 await self.hass.config_entries.async_reload(confirmed_entry_id)
 
@@ -443,7 +453,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             step_id="repair_entity_ids_confirm",
             entry_id=entry_id,
             user_input=user_input,
-            pending=repairs,
+            pending=pending,
             on_confirm=on_repair,
         )
 

--- a/custom_components/fritzbox_vpn/entity.py
+++ b/custom_components/fritzbox_vpn/entity.py
@@ -28,6 +28,49 @@ from .models import FritzboxVpnConfigEntry, RuntimePlatform, runtime_from_entry
 _LOGGER = logging.getLogger(__name__)
 
 EntityFactory = Callable[[FritzBoxVPNCoordinator, set[str]], list]
+VpnEntityFactory = Callable[
+    [FritzBoxVPNCoordinator, FritzboxVpnConfigEntry, str, dict[str, Any]], Any
+]
+VpnConnectionEntitiesFactory = Callable[
+    [FritzBoxVPNCoordinator, FritzboxVpnConfigEntry, str, dict[str, Any]], list[Any]
+]
+
+
+def vpn_entities_for_connections(
+    coordinator: FritzBoxVPNCoordinator,
+    entry: FritzboxVpnConfigEntry,
+    uids: set[str],
+    create_entities: VpnConnectionEntitiesFactory,
+) -> list[Any]:
+    """Create entities for each VPN UID (factory may return multiple per connection)."""
+    if not coordinator.data:
+        return []
+    entities: list[Any] = []
+    for uid in uids:
+        if uid in coordinator.data:
+            entities.extend(
+                create_entities(coordinator, entry, uid, coordinator.data[uid])
+            )
+    return entities
+
+
+def vpn_entities_for_uids(
+    coordinator: FritzBoxVPNCoordinator,
+    entry: FritzboxVpnConfigEntry,
+    uids: set[str],
+    create_entity: VpnEntityFactory,
+) -> list[Any]:
+    """Create one entity per VPN UID that exists in coordinator data."""
+
+    def _create_one(
+        coord: FritzBoxVPNCoordinator,
+        ent: FritzboxVpnConfigEntry,
+        uid: str,
+        conn: dict[str, Any],
+    ) -> list[Any]:
+        return [create_entity(coord, ent, uid, conn)]
+
+    return vpn_entities_for_connections(coordinator, entry, uids, _create_one)
 
 
 def vpn_unique_id(connection_uid: str, suffix: str) -> str:
@@ -110,6 +153,8 @@ class FritzBoxVPNEntity(CoordinatorEntity):
         connection_payload: dict[str, Any],
         *,
         unique_id_suffix: str,
+        translation_key: str | None = None,
+        object_id_suffix: str | None = None,
     ) -> None:
         super().__init__(coordinator)
         self._entry = entry
@@ -119,6 +164,13 @@ class FritzBoxVPNEntity(CoordinatorEntity):
         self._attr_device_info = vpn_device_info(
             entry, connection_uid, connection_payload
         )
+        if translation_key is not None:
+            self._attr_translation_key = translation_key
+            self._attr_object_id_suffix = (
+                object_id_suffix if object_id_suffix is not None else unique_id_suffix
+            )
+        elif object_id_suffix is not None:
+            self._attr_object_id_suffix = object_id_suffix
 
     @property
     def available(self) -> bool:

--- a/custom_components/fritzbox_vpn/entity.py
+++ b/custom_components/fritzbox_vpn/entity.py
@@ -97,7 +97,6 @@ def raise_toggle_failed(vpn_name: str, error: str = "") -> None:
 class FritzBoxVPNEntity(CoordinatorEntity):
     """Base entity bound to one VPN connection on the coordinator."""
 
-    _attr_name = None
     _attr_has_entity_name = True
     _attr_translation_domain = DOMAIN
 

--- a/custom_components/fritzbox_vpn/entity.py
+++ b/custom_components/fritzbox_vpn/entity.py
@@ -99,6 +99,7 @@ class FritzBoxVPNEntity(CoordinatorEntity):
 
     _attr_name = None
     _attr_has_entity_name = True
+    _attr_translation_domain = DOMAIN
 
     def __init__(
         self,

--- a/custom_components/fritzbox_vpn/entity.py
+++ b/custom_components/fritzbox_vpn/entity.py
@@ -130,10 +130,11 @@ def vpn_switch_attributes(
 
 def raise_toggle_failed(vpn_name: str, error: str = "") -> None:
     """Raise translated HomeAssistantError for failed VPN toggle."""
+    error_placeholder = f": {error}" if error else "."
     raise HomeAssistantError(
         translation_domain=DOMAIN,
         translation_key="toggle_failed",
-        translation_placeholders={"name": vpn_name, "error": error},
+        translation_placeholders={"name": vpn_name, "error": error_placeholder},
     )
 
 

--- a/custom_components/fritzbox_vpn/entity.py
+++ b/custom_components/fritzbox_vpn/entity.py
@@ -131,14 +131,14 @@ class FritzBoxVPNEntity(CoordinatorEntity):
 
     @property
     def suggested_object_id(self) -> str | None:
-        """Return a stable object_id for entity_id generation.
+        """Return a stable object_id suffix for entity_id generation.
 
-        HA derives the entity_id from this value; using fixed suffix tokens
-        avoids language-dependent translation differences.
+        With ``has_entity_name=True``, Home Assistant prepends the device name
+        via ``async_calculate_suggested_object_id``; return only the fixed
+        suffix token here to avoid duplicated name parts and language drift.
         """
         if self._attr_object_id_suffix:
-            vpn_name = self._connection_data.get(API_KEY_NAME, DEFAULT_NAME_UNKNOWN)
-            return f"{vpn_name}_{self._attr_object_id_suffix}"
+            return self._attr_object_id_suffix
         return super().suggested_object_id
 
 

--- a/custom_components/fritzbox_vpn/entity.py
+++ b/custom_components/fritzbox_vpn/entity.py
@@ -99,6 +99,8 @@ class FritzBoxVPNEntity(CoordinatorEntity):
 
     _attr_has_entity_name = True
     _attr_translation_domain = DOMAIN
+    # Keep entity_id (object_id) stable across languages by using fixed tokens.
+    _attr_object_id_suffix: str | None = None
 
     def __init__(
         self,
@@ -126,6 +128,18 @@ class FritzBoxVPNEntity(CoordinatorEntity):
     def _vpn_connection(self) -> dict[str, Any] | None:
         """Current connection dict from coordinator, if available."""
         return connection_data(self.coordinator, self._connection_uid)
+
+    @property
+    def suggested_object_id(self) -> str | None:
+        """Return a stable object_id for entity_id generation.
+
+        HA derives the entity_id from this value; using fixed suffix tokens
+        avoids language-dependent translation differences.
+        """
+        if self._attr_object_id_suffix:
+            vpn_name = self._connection_data.get(API_KEY_NAME, DEFAULT_NAME_UNKNOWN)
+            return f"{vpn_name}_{self._attr_object_id_suffix}"
+        return super().suggested_object_id
 
 
 async def setup_vpn_platform(

--- a/custom_components/fritzbox_vpn/entity_registry.py
+++ b/custom_components/fritzbox_vpn/entity_registry.py
@@ -172,7 +172,12 @@ def entity_id_suffix_number(entity_id: str) -> int | None:
 def get_legacy_entity_object_id_repairs(
     hass: HomeAssistant, entry_id: str
 ) -> list[tuple[er.RegistryEntry, str]]:
-    """Rename operations for legacy entity IDs missing suffix tokens."""
+    """Rename operations for legacy entity IDs missing suffix tokens.
+
+    Uses the current device name to compute target entity IDs. Intended for the
+    one-time v1→v2 config-entry migration and explicit user-initiated repair,
+    not for automatic repair on every setup/reload.
+    """
     registry = er.async_get(hass)
     device_registry = dr.async_get(hass)
     repairs: list[tuple[er.RegistryEntry, str]] = []

--- a/custom_components/fritzbox_vpn/entity_registry.py
+++ b/custom_components/fritzbox_vpn/entity_registry.py
@@ -8,8 +8,14 @@ import re
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import slugify
 
-from .const import DOMAIN, UNIQUE_ID_PREFIX, UNIQUE_ID_SUFFIXES
+from .const import (
+    DOMAIN,
+    UNIQUE_ID_PREFIX,
+    UNIQUE_ID_SUFFIX_SWITCH,
+    UNIQUE_ID_SUFFIXES,
+)
 from .models import runtime_from_hass
 
 _LOGGER = logging.getLogger(__name__)
@@ -17,15 +23,49 @@ _LOGGER = logging.getLogger(__name__)
 _ENTITY_ID_OBJECT_ID_SUFFIX_RE = re.compile(r"^(.+)_(\d+)$")
 
 
-def connection_uid_from_entity_unique_id(unique_id: str) -> str | None:
-    """Connection UID from entity unique_id; None if not our format."""
+def unique_id_suffix_from_entity_unique_id(unique_id: str) -> str | None:
+    """Platform suffix token from entity unique_id; None if not our format."""
     if not unique_id or not unique_id.startswith(UNIQUE_ID_PREFIX):
         return None
     rest = unique_id[len(UNIQUE_ID_PREFIX) :]
     for suffix in UNIQUE_ID_SUFFIXES:
         if rest.endswith("_" + suffix):
-            return rest[: -len(suffix) - 1]
+            return suffix
     return None
+
+
+def connection_uid_from_entity_unique_id(unique_id: str) -> str | None:
+    """Connection UID from entity unique_id; None if not our format."""
+    suffix = unique_id_suffix_from_entity_unique_id(unique_id)
+    if suffix is None:
+        return None
+    rest = unique_id[len(UNIQUE_ID_PREFIX) :]
+    return rest[: -len(suffix) - 1]
+
+
+def expected_object_id_for_device_suffix(device_name: str, unique_id_suffix: str) -> str:
+    """Stable object_id slug for a VPN device name and platform suffix."""
+    if unique_id_suffix == UNIQUE_ID_SUFFIX_SWITCH:
+        return slugify(device_name)
+    return slugify(f"{device_name} {unique_id_suffix}")
+
+
+def expected_entity_id_for_registry_entry(
+    device_registry: dr.DeviceRegistry,
+    entry: er.RegistryEntry,
+) -> str | None:
+    """Expected entity_id for a registry entry based on device name and unique_id."""
+    unique_id_suffix = unique_id_suffix_from_entity_unique_id(entry.unique_id or "")
+    if unique_id_suffix is None or not entry.device_id:
+        return None
+    device = device_registry.async_get(entry.device_id)
+    if device is None:
+        return None
+    device_name = device.name_by_user or device.name
+    if not device_name:
+        return None
+    object_id = expected_object_id_for_device_suffix(device_name, unique_id_suffix)
+    return f"{entry.domain}.{object_id}"
 
 
 def resolve_current_uids(
@@ -129,6 +169,53 @@ def entity_id_suffix_number(entity_id: str) -> int | None:
         return None
 
 
+def get_legacy_entity_object_id_repairs(
+    hass: HomeAssistant, entry_id: str
+) -> list[tuple[er.RegistryEntry, str]]:
+    """Rename operations for legacy entity IDs missing suffix tokens."""
+    registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    repairs: list[tuple[er.RegistryEntry, str]] = []
+
+    for entry in er.async_entries_for_config_entry(registry, entry_id):
+        target_entity_id = expected_entity_id_for_registry_entry(device_registry, entry)
+        if target_entity_id is None or entry.entity_id == target_entity_id:
+            continue
+        if registry.async_get(target_entity_id) is not None:
+            continue
+        repairs.append((entry, target_entity_id))
+
+    return repairs
+
+
+def repair_legacy_entity_object_ids(
+    hass: HomeAssistant, entry_id: str
+) -> tuple[int, list[str]]:
+    """Rename legacy entity IDs to current suffix-based object_id scheme."""
+    registry = er.async_get(hass)
+    repairs = get_legacy_entity_object_id_repairs(hass, entry_id)
+    messages: list[str] = []
+    for entry, target_entity_id in repairs:
+        try:
+            registry.async_update_entity(
+                entry.entity_id, new_entity_id=target_entity_id
+            )
+            messages.append(f"{entry.entity_id} → {target_entity_id}")
+            _LOGGER.info(
+                "Repaired legacy entity ID: %s → %s",
+                entry.entity_id,
+                target_entity_id,
+            )
+        except Exception as err:
+            _LOGGER.warning(
+                "Failed to repair legacy entity ID %s → %s: %s",
+                entry.entity_id,
+                target_entity_id,
+                err,
+            )
+    return (len(messages), messages)
+
+
 def get_entity_id_suffix_repairs(
     registry: er.EntityRegistry, entry_id: str
 ) -> list[tuple[er.RegistryEntry, str, bool]]:
@@ -191,6 +278,13 @@ def repair_entity_id_suffixes(
                 err,
             )
     return (len(messages), messages)
+
+
+def repair_entity_ids(hass: HomeAssistant, entry_id: str) -> tuple[int, list[str]]:
+    """Repair legacy object_id suffixes and numeric entity_id suffixes (_2, _3, ...)."""
+    legacy_count, legacy_messages = repair_legacy_entity_object_ids(hass, entry_id)
+    suffix_count, suffix_messages = repair_entity_id_suffixes(hass, entry_id)
+    return (legacy_count + suffix_count, legacy_messages + suffix_messages)
 
 
 def remove_orphaned_entities(

--- a/custom_components/fritzbox_vpn/entity_registry.py
+++ b/custom_components/fritzbox_vpn/entity_registry.py
@@ -61,6 +61,39 @@ def get_orphaned_entity_entries(
     return (to_remove, None)
 
 
+def remove_unexpected_entity_entries(
+    hass: HomeAssistant,
+    entry_id: str,
+    *,
+    current_uids: set[str],
+) -> int:
+    """Remove entity registry entries that are not provided anymore.
+
+    This primarily fixes "shadow" entities caused by wrong/broken unique_id
+    generation across upgrades: if an entry's unique_id does not match any of
+    our expected unique_id values for the currently known VPN connections,
+    remove it from the entity registry.
+    """
+    expected_unique_ids = {
+        f"{UNIQUE_ID_PREFIX}{uid}_{suffix}"
+        for uid in current_uids
+        for suffix in UNIQUE_ID_SUFFIXES
+    }
+
+    entity_registry = er.async_get(hass)
+    to_remove: list[er.RegistryEntry] = []
+    for entry in er.async_entries_for_config_entry(entity_registry, entry_id):
+        unique_id = entry.unique_id or ""
+        if not unique_id.startswith(UNIQUE_ID_PREFIX):
+            continue
+        if unique_id in expected_unique_ids:
+            continue
+        to_remove.append(entry)
+
+    remove_orphaned_entities(hass, entry_id, to_remove)
+    return len(to_remove)
+
+
 def uids_from_entity_entries(entries: list[er.RegistryEntry]) -> set[str]:
     """Connection UIDs from entity registry entries."""
     uids: set[str] = set()

--- a/custom_components/fritzbox_vpn/flow_forms.py
+++ b/custom_components/fritzbox_vpn/flow_forms.py
@@ -175,6 +175,41 @@ def confirm_checkbox_schema() -> vol.Schema:
     return vol.Schema({vol.Required("confirm", default=False): bool})
 
 
+def config_and_options_from_configure_input(
+    user_input: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Split configure/reconfigure form input into entry data and options."""
+    config_data = {
+        CONF_HOST: user_input[CONF_HOST],
+        CONF_USERNAME: user_input[CONF_USERNAME],
+        CONF_PASSWORD: user_input[CONF_PASSWORD],
+    }
+    options_data = {
+        CONF_UPDATE_INTERVAL: normalize_update_interval(
+            user_input.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+        )
+    }
+    return config_data, options_data
+
+
+async def async_validate_configure_input(
+    hass: HomeAssistant,
+    user_input: dict[str, Any],
+    errors: dict[str, str],
+    *password_sources: Mapping[str, Any] | None,
+) -> bool:
+    """Validate host and Fritz!Box connectivity for configure/reconfigure steps."""
+    fill_password_if_missing(user_input, *password_sources)
+    if not validate_host_on_submit(user_input, errors):
+        return False
+    try:
+        await validate_input(hass, user_input)
+    except Exception as err:
+        set_validation_error(errors, err, log_unknown_details=True)
+        return False
+    return True
+
+
 def validation_error_key(error_msg: str) -> str:
     """Map validation exception message to config flow error key."""
     msg_lower = error_msg.lower()

--- a/custom_components/fritzbox_vpn/flow_forms.py
+++ b/custom_components/fritzbox_vpn/flow_forms.py
@@ -146,6 +146,17 @@ def configure_schema(
     )
 
 
+def configure_schema_for_resubmit(user_input: dict[str, Any]) -> vol.Schema:
+    """Configure schema defaults from the latest submitted form values.
+
+    On validation failure the form is re-shown; host/username come from
+    ``current_data`` and the update interval from ``current_options``. Pass the
+    submitted ``user_input`` for both so a typed interval is not reset to stored
+    options.
+    """
+    return configure_schema(user_input, user_input)
+
+
 def confirm_schema(
     existing_config: Mapping[str, Any] | None,
     discovered_host: str | None,

--- a/custom_components/fritzbox_vpn/icons.json
+++ b/custom_components/fritzbox_vpn/icons.json
@@ -1,10 +1,5 @@
 {
   "entity": {
-    "switch": {
-      "vpn": {
-        "default": "mdi:vpn"
-      }
-    },
     "binary_sensor": {
       "connected": {
         "default": "mdi:connection"

--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -16,5 +16,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.2"
+  "version": "1.2.2b3"
 }

--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -16,5 +16,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.2b5"
+  "version": "1.2.2b6"
 }

--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -16,5 +16,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.2b3"
+  "version": "1.2.2b4"
 }

--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -16,5 +16,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.2b4"
+  "version": "1.2.2b5"
 }

--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -16,5 +16,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.2b7"
+  "version": "1.2.2b8"
 }

--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -16,5 +16,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.2b6"
+  "version": "1.2.2b7"
 }

--- a/custom_components/fritzbox_vpn/sensor.py
+++ b/custom_components/fritzbox_vpn/sensor.py
@@ -15,7 +15,7 @@ from .const import (
     VPN_STATUS_OPTIONS,
 )
 from .coordinator import FritzBoxVPNCoordinator
-from .entity import FritzBoxVPNEntity, setup_vpn_platform
+from .entity import FritzBoxVPNEntity, setup_vpn_platform, vpn_entities_for_connections
 from .models import FritzboxVpnConfigEntry
 
 PARALLEL_UPDATES = 1
@@ -28,20 +28,24 @@ async def async_setup_entry(
 ) -> None:
     """Set up FritzBox VPN sensor entities."""
 
+    def _sensors_for_connection(
+        coordinator: FritzBoxVPNCoordinator,
+        entry: FritzboxVpnConfigEntry,
+        uid: str,
+        conn: dict[str, Any],
+    ) -> list[SensorEntity]:
+        return [
+            FritzBoxVPNStatusSensor(coordinator, entry, uid, conn),
+            FritzBoxVPNUIDSensor(coordinator, entry, uid, conn),
+            FritzBoxVPNVPNUIDSensor(coordinator, entry, uid, conn),
+        ]
+
     def _create_entities(
         coordinator: FritzBoxVPNCoordinator, uids: set[str]
     ) -> list[SensorEntity]:
-        if not coordinator.data:
-            return []
-        entities: list[SensorEntity] = []
-        for uid in uids:
-            if uid not in coordinator.data:
-                continue
-            conn = coordinator.data[uid]
-            entities.append(FritzBoxVPNStatusSensor(coordinator, entry, uid, conn))
-            entities.append(FritzBoxVPNUIDSensor(coordinator, entry, uid, conn))
-            entities.append(FritzBoxVPNVPNUIDSensor(coordinator, entry, uid, conn))
-        return entities
+        return vpn_entities_for_connections(
+            coordinator, entry, uids, _sensors_for_connection
+        )
 
     await setup_vpn_platform(
         entry,
@@ -67,9 +71,8 @@ class FritzBoxVPNStatusSensor(FritzBoxVPNEntity, SensorEntity):
             connection_uid,
             connection_data,
             unique_id_suffix=UNIQUE_ID_SUFFIX_STATUS,
+            translation_key="status",
         )
-        self._attr_translation_key = "status"
-        self._attr_object_id_suffix = UNIQUE_ID_SUFFIX_STATUS
         self._attr_device_class = SensorDeviceClass.ENUM
         self._attr_options = list(VPN_STATUS_OPTIONS)
 
@@ -97,9 +100,8 @@ class FritzBoxVPNUIDSensor(FritzBoxVPNEntity, SensorEntity):
             connection_uid,
             connection_data,
             unique_id_suffix=UNIQUE_ID_SUFFIX_UID,
+            translation_key="connection_uid",
         )
-        self._attr_translation_key = "connection_uid"
-        self._attr_object_id_suffix = UNIQUE_ID_SUFFIX_UID
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
@@ -126,9 +128,8 @@ class FritzBoxVPNVPNUIDSensor(FritzBoxVPNEntity, SensorEntity):
             connection_uid,
             connection_data,
             unique_id_suffix=UNIQUE_ID_SUFFIX_VPN_UID,
+            translation_key="vpn_uid",
         )
-        self._attr_translation_key = "vpn_uid"
-        self._attr_object_id_suffix = UNIQUE_ID_SUFFIX_VPN_UID
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property

--- a/custom_components/fritzbox_vpn/sensor.py
+++ b/custom_components/fritzbox_vpn/sensor.py
@@ -68,6 +68,7 @@ class FritzBoxVPNStatusSensor(FritzBoxVPNEntity, SensorEntity):
             connection_data,
             unique_id_suffix=UNIQUE_ID_SUFFIX_STATUS,
         )
+        self._attr_name = "Status"
         self._attr_translation_key = "status"
         self._attr_device_class = SensorDeviceClass.ENUM
         self._attr_options = list(VPN_STATUS_OPTIONS)
@@ -97,6 +98,7 @@ class FritzBoxVPNUIDSensor(FritzBoxVPNEntity, SensorEntity):
             connection_data,
             unique_id_suffix=UNIQUE_ID_SUFFIX_UID,
         )
+        self._attr_name = "UID"
         self._attr_translation_key = "connection_uid"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -125,6 +127,7 @@ class FritzBoxVPNVPNUIDSensor(FritzBoxVPNEntity, SensorEntity):
             connection_data,
             unique_id_suffix=UNIQUE_ID_SUFFIX_VPN_UID,
         )
+        self._attr_name = "VPN UID"
         self._attr_translation_key = "vpn_uid"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 

--- a/custom_components/fritzbox_vpn/sensor.py
+++ b/custom_components/fritzbox_vpn/sensor.py
@@ -68,7 +68,6 @@ class FritzBoxVPNStatusSensor(FritzBoxVPNEntity, SensorEntity):
             connection_data,
             unique_id_suffix=UNIQUE_ID_SUFFIX_STATUS,
         )
-        self._attr_name = "Status"
         self._attr_translation_key = "status"
         self._attr_device_class = SensorDeviceClass.ENUM
         self._attr_options = list(VPN_STATUS_OPTIONS)
@@ -98,7 +97,6 @@ class FritzBoxVPNUIDSensor(FritzBoxVPNEntity, SensorEntity):
             connection_data,
             unique_id_suffix=UNIQUE_ID_SUFFIX_UID,
         )
-        self._attr_name = "UID"
         self._attr_translation_key = "connection_uid"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -127,7 +125,6 @@ class FritzBoxVPNVPNUIDSensor(FritzBoxVPNEntity, SensorEntity):
             connection_data,
             unique_id_suffix=UNIQUE_ID_SUFFIX_VPN_UID,
         )
-        self._attr_name = "VPN UID"
         self._attr_translation_key = "vpn_uid"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 

--- a/custom_components/fritzbox_vpn/sensor.py
+++ b/custom_components/fritzbox_vpn/sensor.py
@@ -69,6 +69,7 @@ class FritzBoxVPNStatusSensor(FritzBoxVPNEntity, SensorEntity):
             unique_id_suffix=UNIQUE_ID_SUFFIX_STATUS,
         )
         self._attr_translation_key = "status"
+        self._attr_object_id_suffix = UNIQUE_ID_SUFFIX_STATUS
         self._attr_device_class = SensorDeviceClass.ENUM
         self._attr_options = list(VPN_STATUS_OPTIONS)
 
@@ -98,6 +99,7 @@ class FritzBoxVPNUIDSensor(FritzBoxVPNEntity, SensorEntity):
             unique_id_suffix=UNIQUE_ID_SUFFIX_UID,
         )
         self._attr_translation_key = "connection_uid"
+        self._attr_object_id_suffix = UNIQUE_ID_SUFFIX_UID
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
@@ -126,6 +128,7 @@ class FritzBoxVPNVPNUIDSensor(FritzBoxVPNEntity, SensorEntity):
             unique_id_suffix=UNIQUE_ID_SUFFIX_VPN_UID,
         )
         self._attr_translation_key = "vpn_uid"
+        self._attr_object_id_suffix = UNIQUE_ID_SUFFIX_VPN_UID
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property

--- a/custom_components/fritzbox_vpn/switch.py
+++ b/custom_components/fritzbox_vpn/switch.py
@@ -14,6 +14,7 @@ from .entity import (
     FritzBoxVPNEntity,
     raise_toggle_failed,
     setup_vpn_platform,
+    vpn_entities_for_uids,
     vpn_switch_attributes,
 )
 from .models import FritzboxVpnConfigEntry
@@ -33,13 +34,7 @@ async def async_setup_entry(
     def _create_entities(
         coordinator: FritzBoxVPNCoordinator, uids: set[str]
     ) -> list[FritzBoxVPNSwitch]:
-        if not coordinator.data:
-            return []
-        return [
-            FritzBoxVPNSwitch(coordinator, entry, uid, coordinator.data[uid])
-            for uid in uids
-            if uid in coordinator.data
-        ]
+        return vpn_entities_for_uids(coordinator, entry, uids, FritzBoxVPNSwitch)
 
     await setup_vpn_platform(
         entry,

--- a/custom_components/fritzbox_vpn/switch.py
+++ b/custom_components/fritzbox_vpn/switch.py
@@ -50,7 +50,11 @@ async def async_setup_entry(
 
 
 class FritzBoxVPNSwitch(FritzBoxVPNEntity, SwitchEntity):
-    """Switch entity for a FritzBox VPN connection."""
+    """Switch entity for a FritzBox VPN connection (main device feature)."""
+
+    # HA best practice: main feature uses device name only (see has_entity_name docs).
+    # Breaking change in 1.2.2b5: entity_id changes from switch.<vpn>_vpn to switch.<vpn>.
+    _attr_name = None
 
     def __init__(
         self,
@@ -66,7 +70,6 @@ class FritzBoxVPNSwitch(FritzBoxVPNEntity, SwitchEntity):
             connection_data,
             unique_id_suffix=UNIQUE_ID_SUFFIX_SWITCH,
         )
-        self._attr_translation_key = "vpn"
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/fritzbox_vpn/translations/de.json
+++ b/custom_components/fritzbox_vpn/translations/de.json
@@ -2,7 +2,7 @@
   "config": {
     "flow_title": "Fritz!Box VPN ({host})",
     "initiate_flow": {
-      "reconfigure": "Neu konfigurieren"
+      "user": "Fritz!Box VPN"
     },
     "step": {
       "user": {

--- a/custom_components/fritzbox_vpn/translations/de.json
+++ b/custom_components/fritzbox_vpn/translations/de.json
@@ -1,5 +1,9 @@
 {
   "config": {
+    "flow_title": "Fritz!Box VPN ({host})",
+    "initiate_flow": {
+      "reconfigure": "Neu konfigurieren"
+    },
     "step": {
       "user": {
         "title": "Fritz!Box VPN Konfiguration",
@@ -17,7 +21,17 @@
       },
       "confirm": {
         "title": "Fritz!Box VPN gefunden",
-        "description": "Eine FritzBox wurde automatisch gefunden: {host}. Bitte bestätigen Sie die Konfiguration."
+        "description": "Eine FritzBox wurde automatisch gefunden: {host}. Bitte bestätigen Sie die Konfiguration.",
+        "data": {
+          "host": "FritzBox IP-Adresse",
+          "username": "Benutzername",
+          "password": "Passwort"
+        },
+        "data_description": {
+          "host": "FritzBox IP-Adresse oder Hostname",
+          "password": "Passwort zur Authentifizierung gegen die FritzBox",
+          "username": "Benutzername zur Authentifizierung gegen die FritzBox"
+        }
       },
       "reauth_confirm": {
         "title": "Fritz!Box VPN erneut anmelden",
@@ -59,8 +73,8 @@
       "already_configured": "Diese FritzBox ist bereits konfiguriert.",
       "not_fritzbox": "Das gefundene Gerät ist keine FritzBox.",
       "no_host": "Die IP-Adresse konnte nicht ermittelt werden.",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+      "reauth_successful": "Erneute Anmeldung war erfolgreich.",
+      "reconfigure_successful": "Neukonfiguration war erfolgreich."
     }
   },
   "options": {
@@ -122,12 +136,16 @@
       "coordinator_not_ready": "Daten werden noch geladen. Bitte kurz warten und erneut versuchen."
     }
   },
-  "entity": {
-    "switch": {
-      "vpn": {
-        "name": "VPN"
+  "selector": {
+    "options_action": {
+      "options": {
+        "configure": "Konfigurieren (Host, Benutzer, Update-Intervall)",
+        "cleanup": "Nicht verfügbare Entitäten entfernen",
+        "repair_entity_ids": "Entitäts-IDs reparieren"
       }
-    },
+    }
+  },
+  "entity": {
     "binary_sensor": {
       "connected": {
         "name": "Verbunden"
@@ -161,10 +179,6 @@
       "name": "Nicht verfügbare Entitäten entfernen",
       "description": "Entitäten löschen, deren VPN-Verbindung auf der Fritz!Box nicht mehr existiert; Integration anschließend neu laden.",
       "fields": {
-        "target": {
-          "name": "Ziel (target)",
-          "description": "Ziel-Entitäten für diese Integration (`fritzbox_vpn`)."
-        },
         "config_entry_id": {
           "name": "Config-Entry-ID",
           "description": "Optional. Bereinigung nur für diesen Konfigurationseintrag. Ohne Angabe: alle Fritz!Box-VPN-Integrationen."
@@ -175,10 +189,6 @@
       "name": "Entitäts-ID-Suffixe reparieren",
       "description": "Entitäts-IDs mit Suffix _2, _3, _4 (z. B. nach fehlerhafter Deaktivierung) auf die Basis-ID zurücksetzen. Verwaisten Basis-Eintrag entfernen.",
       "fields": {
-        "target": {
-          "name": "Ziel (target)",
-          "description": "Ziel-Entitäten für diese Integration (`fritzbox_vpn`)."
-        },
         "config_entry_id": {
           "name": "Config-Entry-ID",
           "description": "Optional. Reparatur nur für diesen Konfigurationseintrag. Ohne Angabe: alle Fritz!Box-VPN-Integrationen."

--- a/custom_components/fritzbox_vpn/translations/en.json
+++ b/custom_components/fritzbox_vpn/translations/en.json
@@ -1,5 +1,9 @@
 {
   "config": {
+    "flow_title": "Fritz!Box VPN ({host})",
+    "initiate_flow": {
+      "reconfigure": "Reconfigure"
+    },
     "step": {
       "user": {
         "title": "Fritz!Box VPN Configuration",
@@ -17,7 +21,17 @@
       },
       "confirm": {
         "title": "Fritz!Box VPN Found",
-        "description": "A FritzBox was automatically discovered: {host}. Please confirm the configuration."
+        "description": "A FritzBox was automatically discovered: {host}. Please confirm the configuration.",
+        "data": {
+          "host": "FritzBox IP Address",
+          "username": "Username",
+          "password": "Password"
+        },
+        "data_description": {
+          "host": "FritzBox IP address or hostname",
+          "password": "Password used to authenticate against the FritzBox",
+          "username": "Username used to authenticate against the FritzBox"
+        }
       },
       "reauth_confirm": {
         "title": "Reauthenticate Fritz!Box VPN",
@@ -29,6 +43,22 @@
         "data_description": {
           "username": "Username used to authenticate against the FritzBox",
           "password": "Password used to authenticate against the FritzBox"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Fritz!Box VPN",
+        "description": "Update your FritzBox connection details. The password field is not displayed for security reasons. Leave it empty to keep the current password, or enter a new password to change it.",
+        "data": {
+          "host": "FritzBox IP Address",
+          "username": "Username",
+          "password": "Password (leave empty to keep current password)",
+          "update_interval": "Update interval (seconds, 5–3600, max. 1 h)"
+        },
+        "data_description": {
+          "host": "FritzBox IP address or hostname",
+          "password": "Password used to authenticate against the FritzBox",
+          "update_interval": "Update interval in seconds",
+          "username": "Username used to authenticate against the FritzBox"
         }
       }
     },
@@ -43,7 +73,8 @@
       "already_configured": "This FritzBox is already configured.",
       "not_fritzbox": "The discovered device is not a FritzBox.",
       "no_host": "Could not determine the IP address.",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "Reauthentication was successful.",
+      "reconfigure_successful": "Reconfiguration was successful."
     }
   },
   "options": {
@@ -105,12 +136,16 @@
       "coordinator_not_ready": "Data is still loading. Please wait a moment and try again."
     }
   },
-  "entity": {
-    "switch": {
-      "vpn": {
-        "name": "VPN"
+  "selector": {
+    "options_action": {
+      "options": {
+        "configure": "Configure (host, user, update interval)",
+        "cleanup": "Remove unavailable entities",
+        "repair_entity_ids": "Repair entity IDs"
       }
-    },
+    }
+  },
+  "entity": {
     "binary_sensor": {
       "connected": {
         "name": "Connected"

--- a/custom_components/fritzbox_vpn/translations/en.json
+++ b/custom_components/fritzbox_vpn/translations/en.json
@@ -2,7 +2,7 @@
   "config": {
     "flow_title": "Fritz!Box VPN ({host})",
     "initiate_flow": {
-      "reconfigure": "Reconfigure"
+      "user": "Fritz!Box VPN"
     },
     "step": {
       "user": {

--- a/custom_components/fritzbox_vpn/translations/en.json
+++ b/custom_components/fritzbox_vpn/translations/en.json
@@ -171,7 +171,7 @@
   },
   "exceptions": {
     "toggle_failed": {
-      "message": "Failed to change VPN connection {name}.{error}"
+      "message": "Failed to change VPN connection {name}{error}"
     }
   },
   "services": {

--- a/docs/releases/v1.2.2b5.md
+++ b/docs/releases/v1.2.2b5.md
@@ -1,0 +1,39 @@
+> **Breaking change:** The VPN switch **entity ID** changes. Update automations and dashboards before upgrading.
+
+## 💥 Breaking changes
+
+The VPN switch is now the device **primary entity** (`has_entity_name` / `_attr_name = None`).
+
+| | Before | After |
+|---|---|---|
+| Display name | e.g. *Office VPN VPN* | e.g. *Office VPN* |
+| Entity ID | `switch.<vpn_name>_vpn` | `switch.<vpn_name>` |
+
+**Example:** `switch.office_vpn_vpn` → `switch.office_vpn`
+
+- `unique_id` is **unchanged** (entity registry may keep your custom name).
+- Automations, scripts, and Lovelace cards that reference the old entity ID must be updated.
+
+### 🇩🇪 Breaking Change (Deutsch)
+
+Die VPN-Switch-Entität ist jetzt die **Hauptfunktion** des Verbindungs-Geräts (`has_entity_name` / `_attr_name = None`).
+
+| | Vorher | Nachher |
+|---|---|---|
+| Anzeigename | z. B. *Office VPN VPN* | z. B. *Office VPN* |
+| Entity-ID | `switch.<vpn_name>_vpn` | `switch.<vpn_name>` |
+
+**Beispiel:** `switch.office_vpn_vpn` → `switch.office_vpn`
+
+- `unique_id` bleibt **unverändert**.
+- Automatisierungen, Skripte und Dashboards mit der alten Entity-ID müssen angepasst werden.
+
+## What's changed
+
+- Switch: Home Assistant–conform primary entity (`_attr_name = None`)
+- Reconfigure flow (host, credentials, update interval)
+- English and German translations for config flow and entities
+- Stable entity ID suffixes for status sensors (`connected`, `status`, …)
+- Automatic cleanup of orphaned shadow entities after reload
+
+**Full Changelog:** https://github.com/rosch100/fritzbox-vpn/compare/v1.2.2b4...v1.2.2b5

--- a/docs/releases/v1.2.2b6.md
+++ b/docs/releases/v1.2.2b6.md
@@ -1,0 +1,18 @@
+## What's changed
+
+- **Automatic entity ID migration on setup/reload** for upgrades from earlier betas:
+  - `binary_sensor.<vpn>` → `binary_sensor.<vpn>_connected`
+  - `sensor.<vpn>` (VPN UID) → `sensor.<vpn>_vpn_uid`
+  - `switch.<vpn>_vpn` → `switch.<vpn>` (if not already migrated in b5)
+- Options flow and service `fritzbox_vpn.repair_entity_id_suffixes` now run the same combined repair (legacy suffixes + `_2`/`_3` numeric suffixes).
+
+After upgrading, reload the integration once (or restart Home Assistant). Check the log for `Repaired legacy entity ID:` messages.
+
+### 🇩🇪 Deutsch
+
+- **Automatische Entity-ID-Migration** beim Setup/Reload nach Upgrade von früheren Betas (siehe Beispiele oben).
+- Options-Flow und Dienst `fritzbox_vpn.repair_entity_id_suffixes` nutzen dieselbe kombinierte Reparatur.
+
+Nach dem Update Integration einmal neu laden (oder HA neu starten). Im Log erscheinen ggf. Meldungen `Repaired legacy entity ID:`.
+
+**Full Changelog:** https://github.com/rosch100/fritzbox-vpn/compare/v1.2.2b5...v1.2.2b6

--- a/docs/releases/v1.2.2b7.md
+++ b/docs/releases/v1.2.2b7.md
@@ -1,0 +1,15 @@
+## What's changed
+
+- **Fix:** Legacy entity ID migration runs **once** via config-entry migration (v1→v2), not on every setup/reload.
+- Entity IDs no longer change again after you rename a VPN device in Home Assistant (automations/dashboards stay stable).
+- Setup still repairs numeric entity ID suffixes (`_2`, `_3`, …) when needed.
+- Manual repair via options flow or service `fritzbox_vpn.repair_entity_id_suffixes` is unchanged.
+
+### 🇩🇪 Deutsch
+
+- **Fix:** Legacy-Entity-ID-Migration läuft **einmalig** über Config-Entry-Migration (v1→v2), nicht bei jedem Setup/Reload.
+- Entity-IDs ändern sich nach Umbenennung eines VPN-Geräts in HA nicht erneut (Automatisierungen/Dashboards bleiben stabil).
+- Setup repariert weiterhin numerische Suffixe (`_2`, `_3`, …) bei Bedarf.
+- Manuelle Reparatur über Options-Flow oder Dienst unverändert.
+
+**Full Changelog:** https://github.com/rosch100/fritzbox-vpn/compare/v1.2.2b6...v1.2.2b7

--- a/docs/releases/v1.2.2b8.md
+++ b/docs/releases/v1.2.2b8.md
@@ -1,0 +1,13 @@
+## What's changed
+
+- **Fix:** Reconfigure and options configure forms now preserve the submitted update interval after validation errors.
+- **Fix:** Reconfigure with an empty password reuses the stored entry credential.
+- **Tests:** Stronger entity-ID repair assertions and coverage for the configure resubmit schema.
+
+### 🇩🇪 Deutsch
+
+- **Fix:** Reconfigure- und Options-Configure-Formulare behalten nach Validierungsfehlern das eingegebene Update-Intervall.
+- **Fix:** Reconfigure mit leerem Passwort nutzt das gespeicherte Entry-Passwort weiter.
+- **Tests:** Strengere Entity-ID-Reparatur-Assertions und Abdeckung für das Configure-Resubmit-Schema.
+
+**Full Changelog:** https://github.com/rosch100/fritzbox-vpn/compare/v1.2.2b7...v1.2.2b8

--- a/tests/test_auto_shadow_entity_cleanup.py
+++ b/tests/test_auto_shadow_entity_cleanup.py
@@ -1,0 +1,61 @@
+"""Auto-cleanup tests for shadow entities during setup."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from custom_components.fritzbox_vpn import async_setup_entry
+from custom_components.fritzbox_vpn.const import DOMAIN, UNIQUE_ID_PREFIX
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from tests.fixtures import MOCK_VPN_CONNECTIONS
+
+
+@pytest.mark.asyncio
+async def test_shadow_entities_removed_on_setup(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Shadow entities with unexpected unique_id values are removed automatically."""
+    mock_config_entry.add_to_hass(hass)
+
+    registry = er.async_get(hass)
+    shadow_unique_id = f"{UNIQUE_ID_PREFIX}conn-abc"  # missing suffix on purpose
+
+    registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        shadow_unique_id,
+        config_entry=mock_config_entry,
+    )
+
+    before = er.async_entries_for_config_entry(
+        registry, mock_config_entry.entry_id
+    )
+    assert any((e.unique_id or "") == shadow_unique_id for e in before)
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = MOCK_VPN_CONNECTIONS
+    mock_coordinator.async_config_entry_first_refresh = AsyncMock(return_value=None)
+    mock_coordinator.fritz_session = MagicMock()
+    mock_coordinator.fritz_session.async_close = AsyncMock()
+    mock_coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+
+    with (
+        patch(
+            "custom_components.fritzbox_vpn.FritzBoxVPNCoordinator",
+            return_value=mock_coordinator,
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new=AsyncMock(return_value=True),
+        ),
+    ):
+        assert await async_setup_entry(hass, mock_config_entry)
+
+    after = er.async_entries_for_config_entry(registry, mock_config_entry.entry_id)
+    assert not any((e.unique_id or "") == shadow_unique_id for e in after)
+

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -355,6 +355,48 @@ async def test_reconfigure_shows_error_on_validation_failure(
 
 
 @pytest.mark.asyncio
+async def test_reconfigure_reuses_stored_password_when_empty(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Reconfigure with empty password reuses the existing entry credential."""
+    mock_config_entry.add_to_hass(hass)
+    original_password = mock_config_entry.data[CONF_PASSWORD]
+
+    with patch(
+        "custom_components.fritzbox_vpn.flow_forms.validate_input",
+        new=AsyncMock(return_value={"title": mock_config_entry.title}),
+    ) as validate_mock, patch.object(
+        hass.config_entries, "async_reload", new=AsyncMock()
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": SOURCE_RECONFIGURE,
+                "entry_id": mock_config_entry.entry_id,
+            },
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "192.168.1.10",
+                CONF_USERNAME: "new-user",
+                CONF_PASSWORD: "",
+                CONF_UPDATE_INTERVAL: 90,
+            },
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    validate_mock.assert_awaited_once()
+    assert validate_mock.await_args.args[1][CONF_PASSWORD] == original_password
+
+    updated = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
+    assert updated is not None
+    assert updated.data[CONF_PASSWORD] == original_password
+    assert updated.options[CONF_UPDATE_INTERVAL] == 90
+
+
+@pytest.mark.asyncio
 async def test_validate_input_maps_connect_error(hass: HomeAssistant) -> None:
     """validate_input raises CannotConnect on connection errors."""
     session_mock = AsyncMock()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,17 +1,17 @@
-"""Tests for FritzBox VPN config flow (user, reauth, validation)."""
+"""Tests for FritzBox VPN config flow (user, reauth, reconfigure, validation)."""
 
 from unittest.mock import AsyncMock, patch
 
 import pytest
 import voluptuous as vol
-from custom_components.fritzbox_vpn.const import DOMAIN
+from custom_components.fritzbox_vpn.const import CONF_UPDATE_INTERVAL, DOMAIN
 from custom_components.fritzbox_vpn.flow_forms import (
     CannotConnect,
     InvalidAuth,
     validate_host,
     validate_input,
 )
-from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_RECONFIGURE, SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -269,6 +269,89 @@ async def test_reauth_shows_error_on_validation_failure(
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"]["base"] == "cannot_connect"
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_updates_entry_without_creating_duplicate(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Reconfigure flow updates data/options on the existing entry only."""
+    mock_config_entry.add_to_hass(hass)
+    entries_before = len(hass.config_entries.async_entries(DOMAIN))
+
+    with patch(
+        "custom_components.fritzbox_vpn.flow_forms.validate_input",
+        new=AsyncMock(return_value={"title": mock_config_entry.title}),
+    ), patch.object(
+        hass.config_entries, "async_reload", new=AsyncMock()
+    ) as reload_mock:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": SOURCE_RECONFIGURE,
+                "entry_id": mock_config_entry.entry_id,
+            },
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "reconfigure"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "192.168.1.10",
+                CONF_USERNAME: "new-user",
+                CONF_PASSWORD: "new-pass",
+                CONF_UPDATE_INTERVAL: 120,
+            },
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == entries_before
+
+    updated = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
+    assert updated is not None
+    assert updated.data[CONF_HOST] == "192.168.1.10"
+    assert updated.data[CONF_USERNAME] == "new-user"
+    assert updated.data[CONF_PASSWORD] == "new-pass"
+    assert updated.options[CONF_UPDATE_INTERVAL] == 120
+    reload_mock.assert_awaited_once_with(mock_config_entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_shows_error_on_validation_failure(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Reconfigure flow shows form again when validation fails."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.fritzbox_vpn.flow_forms.validate_input",
+        new=AsyncMock(side_effect=CannotConnect),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": SOURCE_RECONFIGURE,
+                "entry_id": mock_config_entry.entry_id,
+            },
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "192.168.1.10",
+                CONF_USERNAME: MOCK_USERNAME,
+                CONF_PASSWORD: MOCK_PASSWORD,
+                CONF_UPDATE_INTERVAL: 60,
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"]["base"] == "cannot_connect"
+    assert hass.config_entries.async_get_entry(mock_config_entry.entry_id).data[
+        CONF_HOST
+    ] == mock_config_entry.data[CONF_HOST]
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -41,7 +41,7 @@ async def test_user_flow_create_entry(hass: HomeAssistant) -> None:
         "custom_components.fritzbox_vpn.config_flow.get_existing_fritz_config",
         new=AsyncMock(return_value=None),
     ), patch(
-        "custom_components.fritzbox_vpn.config_flow.validate_input",
+        "custom_components.fritzbox_vpn.flow_forms.validate_input",
         new=AsyncMock(return_value={"title": f"Fritz!Box VPN ({MOCK_HOST})"}),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -70,7 +70,7 @@ async def test_user_flow_invalid_auth(hass: HomeAssistant) -> None:
         "custom_components.fritzbox_vpn.config_flow.get_existing_fritz_config",
         new=AsyncMock(return_value=None),
     ), patch(
-        "custom_components.fritzbox_vpn.config_flow.validate_input",
+        "custom_components.fritzbox_vpn.flow_forms.validate_input",
         new=AsyncMock(side_effect=InvalidAuth),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -118,7 +118,7 @@ async def test_reauth_updates_credentials(hass: HomeAssistant, mock_config_entry
     mock_config_entry.add_to_hass(hass)
 
     with patch(
-        "custom_components.fritzbox_vpn.config_flow.validate_input",
+        "custom_components.fritzbox_vpn.flow_forms.validate_input",
         new=AsyncMock(return_value={"title": mock_config_entry.title}),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -182,7 +182,7 @@ async def test_user_autoconfig_invalid_auth(hass: HomeAssistant) -> None:
             }
         ),
     ), patch(
-        "custom_components.fritzbox_vpn.config_flow.validate_input",
+        "custom_components.fritzbox_vpn.flow_forms.validate_input",
         new=AsyncMock(side_effect=InvalidAuth),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -206,7 +206,7 @@ async def test_user_autoconfig_cannot_connect(hass: HomeAssistant) -> None:
             }
         ),
     ), patch(
-        "custom_components.fritzbox_vpn.config_flow.validate_input",
+        "custom_components.fritzbox_vpn.flow_forms.validate_input",
         new=AsyncMock(side_effect=CannotConnect),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -230,7 +230,7 @@ async def test_user_autoconfig_unknown_error(hass: HomeAssistant) -> None:
             }
         ),
     ), patch(
-        "custom_components.fritzbox_vpn.config_flow.validate_input",
+        "custom_components.fritzbox_vpn.flow_forms.validate_input",
         new=AsyncMock(side_effect=RuntimeError("unexpected")),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -249,7 +249,7 @@ async def test_reauth_shows_error_on_validation_failure(
     mock_config_entry.add_to_hass(hass)
 
     with patch(
-        "custom_components.fritzbox_vpn.config_flow.validate_input",
+        "custom_components.fritzbox_vpn.flow_forms.validate_input",
         new=AsyncMock(side_effect=CannotConnect),
     ):
         result = await hass.config_entries.flow.async_init(

--- a/tests/test_config_flow_confirm.py
+++ b/tests/test_config_flow_confirm.py
@@ -29,7 +29,7 @@ async def test_confirm_step_success(hass: HomeAssistant) -> None:
     hass.config_entries.flow._progress[flow.flow_id] = flow
 
     with patch(
-        "custom_components.fritzbox_vpn.config_flow.validate_input",
+        "custom_components.fritzbox_vpn.flow_forms.validate_input",
         new=AsyncMock(return_value={"title": "Fritz!Box VPN"}),
     ):
         result = await flow.async_step_confirm(
@@ -89,7 +89,7 @@ async def test_confirm_step_validation_error(hass: HomeAssistant) -> None:
     flow._discovered_unique_id = MOCK_HOST
 
     with patch(
-        "custom_components.fritzbox_vpn.config_flow.validate_input",
+        "custom_components.fritzbox_vpn.flow_forms.validate_input",
         new=AsyncMock(side_effect=InvalidAuth),
     ):
         result = await flow.async_step_confirm(

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -6,16 +6,22 @@ from custom_components.fritzbox_vpn.entity_registry import (
     connection_uid_from_entity_unique_id,
     entity_id_base,
     entity_id_suffix_number,
+    expected_object_id_for_device_suffix,
     get_entity_id_suffix_repairs,
+    get_legacy_entity_object_id_repairs,
     get_orphaned_entity_entries,
     remove_orphaned_entities,
     repair_entity_id_suffixes,
+    repair_entity_ids,
+    repair_legacy_entity_object_ids,
     resolve_current_uids,
     uids_from_entity_entries,
+    unique_id_suffix_from_entity_unique_id,
 )
 from custom_components.fritzbox_vpn.models import FritzboxVpnRuntimeData
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -57,6 +63,122 @@ async def test_resolve_current_uids_errors(hass: HomeAssistant) -> None:
     uids, err = resolve_current_uids(hass, entry.entry_id)
     assert uids is None
     assert err == "coordinator_not_ready"
+
+
+def test_unique_id_suffix_from_entity_unique_id() -> None:
+    """Parse platform suffix token from entity unique_id."""
+    uid = "abc"
+    assert (
+        unique_id_suffix_from_entity_unique_id(f"{UNIQUE_ID_PREFIX}{uid}_connected")
+        == "connected"
+    )
+    assert (
+        unique_id_suffix_from_entity_unique_id(f"{UNIQUE_ID_PREFIX}{uid}_vpn_uid")
+        == "vpn_uid"
+    )
+    assert unique_id_suffix_from_entity_unique_id("other") is None
+
+
+def test_expected_object_id_for_device_suffix() -> None:
+    """Expected object_id slugs follow Home Assistant slugify rules."""
+    assert expected_object_id_for_device_suffix("Altanis Berlin", "switch") == (
+        "altanis_berlin"
+    )
+    assert expected_object_id_for_device_suffix("Altanis Berlin", "connected") == (
+        "altanis_berlin_connected"
+    )
+    assert expected_object_id_for_device_suffix("Altanis Berlin", "vpn_uid") == (
+        "altanis_berlin_vpn_uid"
+    )
+
+
+@pytest.mark.asyncio
+async def test_repair_legacy_entity_object_ids(hass: HomeAssistant) -> None:
+    """Legacy entity IDs missing suffix tokens are renamed automatically."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"})
+    entry.add_to_hass(hass)
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.entry_id, "conn1")},
+        name="Altanis Berlin",
+    )
+    connected = entity_registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}conn1_connected",
+        config_entry=entry,
+        device_id=device.id,
+        suggested_object_id="altanis_berlin",
+    )
+    vpn_uid = entity_registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}conn1_vpn_uid",
+        config_entry=entry,
+        device_id=device.id,
+        suggested_object_id="altanis_berlin",
+    )
+    old_switch = entity_registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}conn1_switch",
+        config_entry=entry,
+        device_id=device.id,
+        suggested_object_id="altanis_berlin_vpn",
+    )
+
+    repairs = get_legacy_entity_object_id_repairs(hass, entry.entry_id)
+    assert len(repairs) == 3
+
+    count, messages = repair_legacy_entity_object_ids(hass, entry.entry_id)
+    assert count == 3
+    assert messages
+
+    assert entity_registry.async_get(connected.entity_id) is None
+    assert entity_registry.async_get("binary_sensor.altanis_berlin_connected")
+    assert entity_registry.async_get(vpn_uid.entity_id) is None
+    assert entity_registry.async_get("sensor.altanis_berlin_vpn_uid")
+    assert entity_registry.async_get(old_switch.entity_id) is None
+    assert entity_registry.async_get("switch.altanis_berlin")
+
+
+@pytest.mark.asyncio
+async def test_repair_entity_ids_runs_legacy_before_suffix(hass: HomeAssistant) -> None:
+    """Combined repair handles legacy names and numeric suffixes."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"})
+    entry.add_to_hass(hass)
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.entry_id, "conn1")},
+        name="Altanis Berlin",
+    )
+    entity_registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}conn1_connected",
+        config_entry=entry,
+        device_id=device.id,
+        suggested_object_id="altanis_berlin",
+    )
+    entity_registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}conn1_switch",
+        suggested_object_id="fritzbox_vpn_conn1_switch_2",
+        config_entry=entry,
+    )
+
+    count, _ = repair_entity_ids(hass, entry.entry_id)
+    assert count >= 2
+    assert entity_registry.async_get("binary_sensor.altanis_berlin_connected")
+    switch_entry = entity_registry.async_get("switch.fritzbox_vpn_conn1_switch")
+    assert switch_entry is not None or entity_registry.async_get(
+        "switch.fritzbox_vpn_conn1_switch_2"
+    ) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -175,10 +175,8 @@ async def test_repair_entity_ids_runs_legacy_before_suffix(hass: HomeAssistant) 
     count, _ = repair_entity_ids(hass, entry.entry_id)
     assert count >= 2
     assert entity_registry.async_get("binary_sensor.altanis_berlin_connected")
-    switch_entry = entity_registry.async_get("switch.fritzbox_vpn_conn1_switch")
-    assert switch_entry is not None or entity_registry.async_get(
-        "switch.fritzbox_vpn_conn1_switch_2"
-    ) is None
+    assert entity_registry.async_get("switch.fritzbox_vpn_conn1_switch") is not None
+    assert entity_registry.async_get("switch.fritzbox_vpn_conn1_switch_2") is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_flow_options.py
+++ b/tests/test_config_flow_options.py
@@ -30,7 +30,7 @@ async def test_options_configure_updates_entry(
     mock_config_entry.add_to_hass(hass)
 
     with patch(
-        "custom_components.fritzbox_vpn.config_flow.validate_input",
+        "custom_components.fritzbox_vpn.flow_forms.validate_input",
         new=AsyncMock(return_value={"title": mock_config_entry.title}),
     ), patch.object(
         hass.config_entries, "async_reload", new=AsyncMock()
@@ -128,7 +128,7 @@ async def test_user_autoconfig_from_fritz(hass: HomeAssistant) -> None:
             }
         ),
     ), patch(
-        "custom_components.fritzbox_vpn.config_flow.validate_input",
+        "custom_components.fritzbox_vpn.flow_forms.validate_input",
         new=AsyncMock(return_value={"title": "Fritz!Box VPN"}),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -216,7 +216,7 @@ async def test_options_configure_validation_error(
     """Configure step shows base error when validation fails."""
     mock_config_entry.add_to_hass(hass)
     with patch(
-        "custom_components.fritzbox_vpn.config_flow.validate_input",
+        "custom_components.fritzbox_vpn.flow_forms.validate_input",
         new=AsyncMock(side_effect=CannotConnect),
     ):
         handler = OptionsFlowHandler(mock_config_entry)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -58,7 +58,8 @@ def test_switch_available_and_state(mock_config_entry: MockConfigEntry) -> None:
     )
     assert entity.available
     assert entity.is_on
-    assert entity.translation_key == "vpn"
+    assert entity.name is None
+    assert entity.translation_key is None
 
 
 def test_binary_sensor_connected(mock_config_entry: MockConfigEntry) -> None:

--- a/tests/test_flow_forms.py
+++ b/tests/test_flow_forms.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 import voluptuous as vol
 from custom_components.fritzbox_vpn.const import (
+    CONF_UPDATE_INTERVAL,
     ERROR_KEY_CANNOT_CONNECT,
     ERROR_KEY_INVALID_AUTH,
     ERROR_KEY_INVALID_HOST,
@@ -14,6 +15,7 @@ from custom_components.fritzbox_vpn.flow_forms import (
     CannotConnect,
     InvalidAuth,
     configure_schema,
+    configure_schema_for_resubmit,
     confirm_checkbox_schema,
     confirm_schema,
     credentials_defaults,
@@ -64,6 +66,31 @@ def test_configure_schema_invalid_host_fallback() -> None:
     """Invalid stored host falls back to default in configure schema."""
     schema = configure_schema({CONF_HOST: ".bad", CONF_USERNAME: "u"}, {})
     assert schema is not None
+
+
+def _schema_field_default(schema: vol.Schema, field: str) -> object:
+    """Return the voluptuous default for a schema field."""
+    for marker in schema.schema:
+        if marker.schema == field:
+            default = marker.default
+            return default() if callable(default) else default
+    raise AssertionError(f"Field {field!r} not found in schema")
+
+
+def test_configure_schema_for_resubmit_preserves_update_interval() -> None:
+    """Re-shown configure forms keep a submitted update interval."""
+    submitted = {
+        CONF_HOST: "192.168.1.10",
+        CONF_USERNAME: "user",
+        CONF_UPDATE_INTERVAL: 60,
+    }
+    stale_options = {CONF_UPDATE_INTERVAL: 30}
+
+    resubmit_schema = configure_schema_for_resubmit(submitted)
+    stale_schema = configure_schema(submitted, stale_options)
+
+    assert _schema_field_default(resubmit_schema, CONF_UPDATE_INTERVAL) == 60
+    assert _schema_field_default(stale_schema, CONF_UPDATE_INTERVAL) == 30
 
 
 def test_confirm_schema_with_current_input() -> None:

--- a/tests/test_legacy_entity_id_repair_on_setup.py
+++ b/tests/test_legacy_entity_id_repair_on_setup.py
@@ -1,0 +1,79 @@
+"""Setup-time repair for legacy entity IDs missing suffix tokens."""
+
+from __future__ import annotations
+
+import pytest
+from custom_components.fritzbox_vpn import _repair_entity_ids_before_platform_setup
+from custom_components.fritzbox_vpn.const import (
+    DOMAIN,
+    UNIQUE_ID_SUFFIX_CONNECTED,
+    UNIQUE_ID_SUFFIX_SWITCH,
+    UNIQUE_ID_SUFFIX_VPN_UID,
+)
+from custom_components.fritzbox_vpn.entity import vpn_unique_id
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+
+from tests.fixtures import MOCK_VPN_CONNECTIONS
+
+
+@pytest.mark.asyncio
+async def test_setup_repairs_legacy_entity_ids_before_platforms(
+    hass, mock_config_entry
+) -> None:
+    """Upgrade path renames legacy entity IDs before platform setup runs."""
+    mock_config_entry.add_to_hass(hass)
+    connection_uid = next(iter(MOCK_VPN_CONNECTIONS))
+    vpn_name = MOCK_VPN_CONNECTIONS[connection_uid]["name"]
+
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, mock_config_entry.entry_id, connection_uid)},
+        name=vpn_name,
+    )
+    slug = vpn_name.lower().replace(" ", "_")
+
+    entity_registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_CONNECTED),
+        config_entry=mock_config_entry,
+        device_id=device.id,
+        suggested_object_id=slug,
+    )
+    entity_registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_VPN_UID),
+        config_entry=mock_config_entry,
+        device_id=device.id,
+        suggested_object_id=slug,
+    )
+    entity_registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_SWITCH),
+        config_entry=mock_config_entry,
+        device_id=device.id,
+        suggested_object_id=f"{slug}_vpn",
+    )
+
+    repaired = _repair_entity_ids_before_platform_setup(hass, mock_config_entry.entry_id)
+    assert repaired == 3
+
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    unique_id_to_entity_id = {entry.unique_id: entry.entity_id for entry in entries}
+
+    assert unique_id_to_entity_id[
+        vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_CONNECTED)
+    ].endswith("_connected")
+    assert unique_id_to_entity_id[
+        vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_VPN_UID)
+    ].endswith("_vpn_uid")
+    assert unique_id_to_entity_id[
+        vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_SWITCH)
+    ] == f"switch.{slug}"

--- a/tests/test_legacy_entity_id_repair_on_setup.py
+++ b/tests/test_legacy_entity_id_repair_on_setup.py
@@ -1,9 +1,12 @@
-"""Setup-time repair for legacy entity IDs missing suffix tokens."""
+"""One-time legacy entity ID migration (config entry v1→v2)."""
 
 from __future__ import annotations
 
 import pytest
-from custom_components.fritzbox_vpn import _repair_entity_ids_before_platform_setup
+from custom_components.fritzbox_vpn import (
+    _repair_entity_ids_before_platform_setup,
+    async_migrate_entry,
+)
 from custom_components.fritzbox_vpn.const import (
     DOMAIN,
     UNIQUE_ID_SUFFIX_CONNECTED,
@@ -17,20 +20,19 @@ from homeassistant.helpers import entity_registry as er
 from tests.fixtures import MOCK_VPN_CONNECTIONS
 
 
-@pytest.mark.asyncio
-async def test_setup_repairs_legacy_entity_ids_before_platforms(
-    hass, mock_config_entry
-) -> None:
-    """Upgrade path renames legacy entity IDs before platform setup runs."""
-    mock_config_entry.add_to_hass(hass)
-    connection_uid = next(iter(MOCK_VPN_CONNECTIONS))
-    vpn_name = MOCK_VPN_CONNECTIONS[connection_uid]["name"]
-
+def _seed_legacy_entities(
+    hass,
+    config_entry,
+    *,
+    connection_uid: str,
+    vpn_name: str,
+) -> tuple[str, er.EntityRegistry]:
+    """Register legacy entity IDs for one VPN connection device."""
     entity_registry = er.async_get(hass)
     device_registry = dr.async_get(hass)
     device = device_registry.async_get_or_create(
-        config_entry_id=mock_config_entry.entry_id,
-        identifiers={(DOMAIN, mock_config_entry.entry_id, connection_uid)},
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, config_entry.entry_id, connection_uid)},
         name=vpn_name,
     )
     slug = vpn_name.lower().replace(" ", "_")
@@ -39,7 +41,7 @@ async def test_setup_repairs_legacy_entity_ids_before_platforms(
         "binary_sensor",
         DOMAIN,
         vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_CONNECTED),
-        config_entry=mock_config_entry,
+        config_entry=config_entry,
         device_id=device.id,
         suggested_object_id=slug,
     )
@@ -47,7 +49,7 @@ async def test_setup_repairs_legacy_entity_ids_before_platforms(
         "sensor",
         DOMAIN,
         vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_VPN_UID),
-        config_entry=mock_config_entry,
+        config_entry=config_entry,
         device_id=device.id,
         suggested_object_id=slug,
     )
@@ -55,13 +57,31 @@ async def test_setup_repairs_legacy_entity_ids_before_platforms(
         "switch",
         DOMAIN,
         vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_SWITCH),
-        config_entry=mock_config_entry,
+        config_entry=config_entry,
         device_id=device.id,
         suggested_object_id=f"{slug}_vpn",
     )
+    return slug, entity_registry
 
-    repaired = _repair_entity_ids_before_platform_setup(hass, mock_config_entry.entry_id)
-    assert repaired == 3
+
+@pytest.mark.asyncio
+async def test_migrate_entry_v1_repairs_legacy_entity_ids(
+    hass, mock_config_entry
+) -> None:
+    """Config entry v1→v2 migration renames legacy entity IDs once."""
+    mock_config_entry.add_to_hass(hass)
+    connection_uid = next(iter(MOCK_VPN_CONNECTIONS))
+    vpn_name = MOCK_VPN_CONNECTIONS[connection_uid]["name"]
+    slug, entity_registry = _seed_legacy_entities(
+        hass,
+        mock_config_entry,
+        connection_uid=connection_uid,
+        vpn_name=vpn_name,
+    )
+
+    assert mock_config_entry.version == 1
+    assert await async_migrate_entry(hass, mock_config_entry)
+    assert mock_config_entry.version == 2
 
     entries = er.async_entries_for_config_entry(
         entity_registry, mock_config_entry.entry_id
@@ -77,3 +97,80 @@ async def test_setup_repairs_legacy_entity_ids_before_platforms(
     assert unique_id_to_entity_id[
         vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_SWITCH)
     ] == f"switch.{slug}"
+
+
+@pytest.mark.asyncio
+async def test_migrate_entry_v2_skips_legacy_repair(hass, mock_config_entry) -> None:
+    """Already-migrated config entries do not run legacy repair again."""
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(mock_config_entry, version=2)
+    connection_uid = next(iter(MOCK_VPN_CONNECTIONS))
+    vpn_name = MOCK_VPN_CONNECTIONS[connection_uid]["name"]
+    slug, entity_registry = _seed_legacy_entities(
+        hass,
+        mock_config_entry,
+        connection_uid=connection_uid,
+        vpn_name=vpn_name,
+    )
+
+    assert await async_migrate_entry(hass, mock_config_entry)
+
+    unique_id_to_entity_id = {
+        entry.unique_id: entry.entity_id
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+    }
+    assert unique_id_to_entity_id[
+        vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_CONNECTED)
+    ] == f"binary_sensor.{slug}"
+    assert unique_id_to_entity_id[
+        vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_SWITCH)
+    ] == f"switch.{slug}_vpn"
+
+
+@pytest.mark.asyncio
+async def test_setup_does_not_rename_entities_after_device_rename(
+    hass, mock_config_entry
+) -> None:
+    """Setup-time repair must not follow later device renames."""
+    mock_config_entry.add_to_hass(hass)
+    connection_uid = next(iter(MOCK_VPN_CONNECTIONS))
+    vpn_name = MOCK_VPN_CONNECTIONS[connection_uid]["name"]
+    slug, entity_registry = _seed_legacy_entities(
+        hass,
+        mock_config_entry,
+        connection_uid=connection_uid,
+        vpn_name=vpn_name,
+    )
+
+    assert await async_migrate_entry(hass, mock_config_entry)
+    assert mock_config_entry.version == 2
+
+    entries_after_migration = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    unique_id_to_entity_id = {
+        entry.unique_id: entry.entity_id for entry in entries_after_migration
+    }
+    connected_entity_id = unique_id_to_entity_id[
+        vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_CONNECTED)
+    ]
+    switch_entity_id = unique_id_to_entity_id[
+        vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_SWITCH)
+    ]
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry.entry_id, connection_uid)}
+    )
+    assert device is not None
+    device_registry.async_update_device(device.id, name_by_user="Renamed VPN")
+
+    repaired = _repair_entity_ids_before_platform_setup(hass, mock_config_entry.entry_id)
+    assert repaired == 0
+
+    assert entity_registry.async_get(connected_entity_id) is not None
+    assert entity_registry.async_get(switch_entity_id) is not None
+    assert connected_entity_id == f"binary_sensor.{slug}_connected"
+    assert switch_entity_id == f"switch.{slug}"

--- a/tests/test_reload_no_entity_duplicates.py
+++ b/tests/test_reload_no_entity_duplicates.py
@@ -94,6 +94,11 @@ async def test_reload_does_not_duplicate_entity_registry_entries(
                 vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_VPN_UID)
             ].endswith("_vpn_uid")
 
+            switch_entity_id = unique_id_to_entity_id[
+                vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_SWITCH)
+            ]
+            assert not switch_entity_id.endswith("_vpn_vpn")
+
     def _factory(*_args, **_kwargs):
         return _make_fake_coordinator(hass)
 

--- a/tests/test_reload_no_entity_duplicates.py
+++ b/tests/test_reload_no_entity_duplicates.py
@@ -1,0 +1,125 @@
+"""Regression tests for avoiding entity duplication on reload."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from custom_components.fritzbox_vpn.const import (
+    STATUS_CONNECTED,
+    STATUS_DISABLED,
+    STATUS_ENABLED,
+    UNIQUE_ID_SUFFIX_CONNECTED,
+    UNIQUE_ID_SUFFIX_STATUS,
+    UNIQUE_ID_SUFFIX_SWITCH,
+    UNIQUE_ID_SUFFIX_UID,
+    UNIQUE_ID_SUFFIX_VPN_UID,
+)
+from custom_components.fritzbox_vpn.entity import vpn_unique_id
+from homeassistant.helpers import entity_registry as er
+
+from tests.fixtures import MOCK_VPN_CONNECTIONS
+
+
+def _fake_get_vpn_status(connection_data: dict) -> str:
+    """Return coordinator status consistent with coordinator.get_vpn_status()."""
+    active = connection_data.get("active", False)
+    if not active:
+        return STATUS_DISABLED
+    return STATUS_CONNECTED if connection_data.get("connected", False) else STATUS_ENABLED
+
+
+def _make_fake_coordinator(hass) -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.hass = hass
+    coordinator.data = dict(MOCK_VPN_CONNECTIONS)
+    coordinator.last_update_success = True
+
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+
+    coordinator.get_vpn_status = MagicMock(
+        side_effect=lambda uid: _fake_get_vpn_status(coordinator.data[uid])
+    )
+    coordinator.toggle_vpn = AsyncMock(return_value=True)
+
+    coordinator.fritz_session = MagicMock()
+    coordinator.fritz_session.async_close = AsyncMock()
+
+    coordinator.async_config_entry_first_refresh = AsyncMock(
+        side_effect=lambda: None
+    )
+
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_reload_does_not_duplicate_entity_registry_entries(
+    hass, mock_config_entry
+) -> None:
+    """Reload must not create a new set of entities (no endless _2/_3 suffixes)."""
+    mock_config_entry.add_to_hass(hass)
+
+    expected_unique_ids = set()
+    for connection_uid in MOCK_VPN_CONNECTIONS:
+        expected_unique_ids |= {
+            vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_SWITCH),
+            vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_CONNECTED),
+            vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_STATUS),
+            vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_UID),
+            vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_VPN_UID),
+        }
+
+    def _assert_registry_entries(entries) -> None:
+        unique_id_to_entity_id = {e.unique_id: e.entity_id for e in entries}
+        assert {e.unique_id for e in entries} == expected_unique_ids
+        assert len(entries) == len(expected_unique_ids)
+
+        for connection_uid in MOCK_VPN_CONNECTIONS:
+            assert unique_id_to_entity_id[
+                vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_CONNECTED)
+            ].endswith("_connected")
+            assert unique_id_to_entity_id[
+                vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_STATUS)
+            ].endswith("_status")
+
+            uid_entity_id = unique_id_to_entity_id[
+                vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_UID)
+            ]
+            assert uid_entity_id.endswith("_uid") or uid_entity_id.endswith(
+                "_connection_uid"
+            )
+
+            assert unique_id_to_entity_id[
+                vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_VPN_UID)
+            ].endswith("_vpn_uid")
+
+    def _factory(*_args, **_kwargs):
+        return _make_fake_coordinator(hass)
+
+    with patch(
+        "custom_components.fritzbox_vpn.FritzBoxVPNCoordinator",
+        side_effect=_factory,
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+        entity_registry = er.async_get(hass)
+        entries = er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+        _assert_registry_entries(entries)
+
+        await hass.config_entries.async_reload(mock_config_entry.entry_id)
+
+        entries_after_reload = er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+        _assert_registry_entries(entries_after_reload)
+
+        await hass.config_entries.async_reload(mock_config_entry.entry_id)
+
+        entries_after_second_reload = er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+        _assert_registry_entries(entries_after_second_reload)
+

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -53,7 +53,7 @@ async def test_repair_entity_id_suffixes_service(
     """Service repairs suffixed entity IDs when configured."""
     mock_config_entry.add_to_hass(hass)
     with patch(
-        "custom_components.fritzbox_vpn.entity_registry.repair_entity_id_suffixes",
+        "custom_components.fritzbox_vpn.entity_registry.repair_entity_ids",
         return_value=(0, []),
     ), patch.object(hass.config_entries, "async_reload", new=AsyncMock()):
         await _async_repair_entity_id_suffixes(


### PR DESCRIPTION
## Summary

- **Breaking change (1.2.2b5):** VPN switch is now the device primary entity (`_attr_name = None`). Entity ID changes from `switch.<vpn>_vpn` to `switch.<vpn>` (e.g. `switch.office_vpn_vpn` → `switch.office_vpn`); `unique_id` unchanged.
- **Entity IDs:** Stable suffix tokens for sensors/binary sensors (`connected`, `status`, …) via `has_entity_name` / `suggested_object_id`.
- **Setup cleanup:** Best-effort removal of shadow/orphaned entity registry entries on setup and reload.
- **Reconfigure flow:** Update host, credentials, and update interval via UI (`async_step_reconfigure`).
- **Translations:** Full EN/DE coverage; hassfest-valid `initiate_flow.user` keys.
- **Release notes:** `docs/releases/v1.2.2b5.md` for HACS/HA update dialog.

## Test plan

- [x] `ruff check custom_components tests`
- [x] `pytest tests/ --cov=custom_components/fritzbox_vpn -q` (154 tests, ≥85% coverage)
- [x] hassfest via Docker (`Invalid integrations: 0`)
- [x] Reconfigure flow tests (`test_reconfigure_*`)

## Checklist

- [x] No secrets in diff
- [x] SSDP logic only in `ssdp_unique_id.py`
- [x] `manifest.json` version `1.2.2b5`
- [x] Breaking change documented in GitHub release notes (not README)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of unexpected VPN entities during setup and reload.
  * Improved entity naming and ID handling to keep names stable across languages and updates.
  * Expanded options and repair flows with clearer choices for configuring, cleaning up, and repairing entities.

* **Bug Fixes**
  * Prevented duplicate entity entries after repeated reloads.
  * Added automatic migration for older entity IDs to the current naming scheme.
  * Improved setup and form validation so configuration errors are handled more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->