### PR TITLE
Release 1.2.2

### DIFF
--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -16,5 +16,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.2b8"
+  "version": "1.2.2"
 }

--- a/docs/releases/v1.2.2.md
+++ b/docs/releases/v1.2.2.md
@@ -1,0 +1,21 @@
+> **Breaking change:** The VPN switch **entity ID** changes from `switch.<vpn_name>_vpn` to `switch.<vpn_name>`. Update automations and dashboards.
+
+## What's changed (since v1.2.1)
+
+- **VPN switch entity ID and name simplified.** The switch is now the device's primary entity: `switch.<vpn_name>_vpn` → `switch.<vpn_name>`, and the display name no longer repeats "VPN" (e.g. *Office VPN VPN* → *Office VPN*). `unique_id` is unchanged, so a custom name you set stays.
+- **Reconfigure from the UI.** Change host, credentials, and update interval without removing and re-adding the integration.
+- **Stable, language-independent entity IDs.** Status entities use fixed suffixes (`_connected`, `_status`, `_vpn_uid`, …) regardless of the selected language. Old IDs from earlier versions are migrated automatically once on upgrade; later device renames no longer change entity IDs.
+- **Automatic cleanup** of orphaned entities left behind by removed VPN connections.
+- **Full German and English translations** for setup, options, and entities.
+- **Fixes:** the update interval is kept after a form validation error, and reconfiguring with an empty password reuses the stored one.
+
+### 🇩🇪 Was ist neu (seit v1.2.1)
+
+- **VPN-Switch: Entity-ID und Name vereinfacht.** Der Switch ist jetzt die Hauptentität des Geräts: `switch.<vpn_name>_vpn` → `switch.<vpn_name>`, und der Anzeigename wiederholt "VPN" nicht mehr (z. B. *Office VPN VPN* → *Office VPN*). Die `unique_id` bleibt gleich – ein eigener Name bleibt erhalten.
+- **Rekonfiguration über die UI.** Host, Zugangsdaten und Update-Intervall ändern, ohne die Integration zu entfernen und neu hinzuzufügen.
+- **Stabile, sprachunabhängige Entity-IDs.** Status-Entitäten nutzen feste Suffixe (`_connected`, `_status`, `_vpn_uid`, …) unabhängig von der Sprache. Alte IDs früherer Versionen werden beim Upgrade einmalig automatisch migriert; spätere Geräte-Umbenennungen ändern die Entity-IDs nicht mehr.
+- **Automatisches Aufräumen** verwaister Entitäten von entfernten VPN-Verbindungen.
+- **Vollständige deutsche und englische Übersetzungen** für Einrichtung, Optionen und Entitäten.
+- **Fixes:** Das Update-Intervall bleibt nach einem Formular-Validierungsfehler erhalten, und Rekonfiguration mit leerem Passwort nutzt das gespeicherte weiter.
+
+**Full Changelog:** https://github.com/rosch100/fritzbox-vpn/compare/v1.2.1...v1.2.2


### PR DESCRIPTION
## Summary

Final 1.2.2 release. Bumps `manifest.json` to `1.2.2` and adds consolidated release notes (`docs/releases/v1.2.2.md`) covering the changes accumulated across the 1.2.2 betas versus v1.2.1:

- Simplified VPN switch entity ID/name (`switch.<name>_vpn` → `switch.<name>`, breaking)
- UI reconfigure flow (host, credentials, update interval)
- Stable, language-independent entity IDs with one-time migration
- Automatic cleanup of orphaned entities
- Full DE/EN translations
- Form update-interval and empty-password reuse fixes

## Test plan

- [x] `ruff check custom_components tests`
- [x] `pytest tests/` (163 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for v1.2.2, including the new VPN switch naming convention and upgrade behavior.
  * Documented in-app reconfiguration improvements, automatic migration of older entity IDs, and cleanup of unused entities.
  * Noted updated German and English translations, plus fixes for saved update intervals and reusing stored credentials during reconfiguration.
* **Chores**
  * Updated the integration version to v1.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->