### PR TITLE
Bump version to 1.2.3

### DIFF
--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -16,5 +16,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.2"
+  "version": "1.2.3"
 }


### PR DESCRIPTION
## Summary

- Bumps `manifest.json` version to `1.2.3` for the next development cycle.

No functional changes.