### PR TITLE
fix: Recovery nach Fritz!Box-Reboot und sicheres Entity-ID-Repair (#42, #37)

### DIFF
--- a/custom_components/fritzbox_vpn/const.py
+++ b/custom_components/fritzbox_vpn/const.py
@@ -126,11 +126,12 @@ REPEATER_INDICATORS = (
     "fritz!wlanrepeater",
 )
 
-ERROR_INDICATOR_AUTH = ("login failed", "invalid sid")
+# Credential/login failures only — session-expiry "Invalid SID (...)" must not
+# trigger reauth or ConfigEntryAuthFailed (see issue #42).
+ERROR_INDICATOR_AUTH = ("login failed",)
 ERROR_INDICATOR_CONNECT = ("failed to get login page", "connection")
 AUTH_INDICATORS = (
     "login failed",
-    "invalid sid",
     "authentication failed",
     "invalid credentials",
     "unauthorized",

--- a/custom_components/fritzbox_vpn/coordinator.py
+++ b/custom_components/fritzbox_vpn/coordinator.py
@@ -125,8 +125,14 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
         return STATUS_CONNECTED if connected else STATUS_ENABLED
 
     def _is_auth_error(self, error: Exception) -> bool:
-        """True if error message indicates authentication failure."""
+        """True if error message indicates credential/authentication failure."""
         return any(ind in str(error).lower() for ind in AUTH_INDICATORS)
+
+    def _prepare_session_for_retry(self, error: Exception) -> None:
+        """Drop cached SID/protocol after transient failures so the next poll recovers."""
+        if self._is_auth_error(error):
+            return
+        self.fritz_session.invalidate_session()
 
     def _schedule_reauth(self) -> None:
         """Start re-authentication flow once per auth failure cycle."""
@@ -171,6 +177,7 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
             self._reauth_scheduled = False
             return connections
         except (ConnectionError, ValueError) as err:
+            self._prepare_session_for_retry(err)
             if self._is_auth_error(err):
                 self._schedule_reauth()
                 raise UpdateFailed(f"Error fetching VPN data: {err}") from err
@@ -179,11 +186,13 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
                 retry_after=RETRY_AFTER_SECONDS,
             ) from err
         except TimeoutError as err:
+            self._prepare_session_for_retry(err)
             raise UpdateFailed(
                 f"Error fetching VPN data: {err}",
                 retry_after=RETRY_AFTER_SECONDS,
             ) from err
         except Exception as err:
+            self._prepare_session_for_retry(err)
             if self._is_auth_error(err):
                 self._schedule_reauth()
                 raise UpdateFailed(

--- a/custom_components/fritzbox_vpn/entity_registry.py
+++ b/custom_components/fritzbox_vpn/entity_registry.py
@@ -271,7 +271,13 @@ def repair_entity_id_suffixes(
     *,
     allow_replace_base: bool = False,
 ) -> tuple[int, list[str]]:
-    """Repair suffixed entity IDs (_2, _3, ...) to base IDs when base is free."""
+    """Repair suffixed entity IDs (_2, _3, ...) toward base IDs.
+
+    Default (``allow_replace_base=False``): only rename when the base
+    entity_id is free. Opt-in ``allow_replace_base=True`` is destructive:
+    a same-entry base entity may be removed so a ``_2``/``_3`` entry can
+    take the base ID (manual repair / service only — not used on setup).
+    """
     registry = er.async_get(hass)
     repairs = get_entity_id_suffix_repairs(
         registry, entry_id, allow_replace_base=allow_replace_base

--- a/custom_components/fritzbox_vpn/entity_registry.py
+++ b/custom_components/fritzbox_vpn/entity_registry.py
@@ -222,9 +222,17 @@ def repair_legacy_entity_object_ids(
 
 
 def get_entity_id_suffix_repairs(
-    registry: er.EntityRegistry, entry_id: str
+    registry: er.EntityRegistry,
+    entry_id: str,
+    *,
+    allow_replace_base: bool = False,
 ) -> list[tuple[er.RegistryEntry, str, bool]]:
-    """Repair operations as (suffixed entry, base_entity_id, remove_base_first)."""
+    """Repair operations as (suffixed entry, base_entity_id, remove_base_first).
+
+    By default only renames when the base entity_id is free. Replacing an
+    existing base (delete base, rename ``_2``) causes recorder history
+    migration warnings and can orphan correct entities on every reload.
+    """
     all_entries = er.async_entries_for_config_entry(registry, entry_id)
     by_entity_id = {e.entity_id: e for e in all_entries}
     suffixed_by_base: dict[str, list[er.RegistryEntry]] = {}
@@ -249,18 +257,27 @@ def get_entity_id_suffix_repairs(
             result.append((preferred, base_entity_id, False))
             continue
 
-        if base_entry and base_entry.config_entry_id == entry_id:
+        if (
+            allow_replace_base
+            and base_entry
+            and base_entry.config_entry_id == entry_id
+        ):
             result.append((preferred, base_entity_id, True))
 
     return result
 
 
 def repair_entity_id_suffixes(
-    hass: HomeAssistant, entry_id: str
+    hass: HomeAssistant,
+    entry_id: str,
+    *,
+    allow_replace_base: bool = False,
 ) -> tuple[int, list[str]]:
-    """Repair suffixed entity IDs (_2, _3, ...) to base IDs."""
+    """Repair suffixed entity IDs (_2, _3, ...) to base IDs when base is free."""
     registry = er.async_get(hass)
-    repairs = get_entity_id_suffix_repairs(registry, entry_id)
+    repairs = get_entity_id_suffix_repairs(
+        registry, entry_id, allow_replace_base=allow_replace_base
+    )
     messages: list[str] = []
     for suffixed_entry, base_entity_id, remove_base_first in repairs:
         try:

--- a/custom_components/fritzbox_vpn/fritzconnection_session.py
+++ b/custom_components/fritzbox_vpn/fritzconnection_session.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from fritzboxvpn.const import DEFAULT_TIMEOUT
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import Timeout as RequestsTimeout
 
@@ -82,10 +83,13 @@ class FritzConnectionVPNSession:
             self._mode = "fritzboxvpn"
             return
 
+        # Router API discovery happens here — callers must invoke this from a
+        # path that maps Timeout/Connection/auth errors (see async_* methods).
         self._fc = FritzConnection(
             address=self._host,
             user=self._username or None,
             password=self._password,
+            timeout=float(DEFAULT_TIMEOUT),
             use_tls=self._use_tls,
         )
         self._fwg = FritzWireguard(fc=self._fc)
@@ -143,24 +147,26 @@ class FritzConnectionVPNSession:
         return self._fwg.toggle_vpn(connection_uid, enable)
 
     async def async_close(self) -> None:
-        await self._hass.async_add_executor_job(self._ensure_client)
-        if self._mode == "fritzboxvpn":
-            assert self._fallback_session is not None
+        """Close only already-initialized transport; never bootstrap a client."""
+        if self._fallback_session is not None:
             await self._fallback_session.async_close()
             return
-        await self._hass.async_add_executor_job(self._close_sync)
+        if self._fc is not None:
+            await self._hass.async_add_executor_job(self._close_sync)
 
     async def async_get_vpn_connections(self) -> dict[str, Any]:
         """Fetch latest VPN connections with HTTPS->HTTP fallback."""
-        await self._hass.async_add_executor_job(self._ensure_client)
-        if self._mode == "fritzboxvpn":
-            assert self._fallback_session is not None
-            return await self._fallback_session.async_get_vpn_connections()
         try:
+            # Bootstrap (FritzConnection discovery) is inside the guarded path.
+            await self._hass.async_add_executor_job(self._ensure_client)
+            if self._mode == "fritzboxvpn":
+                assert self._fallback_session is not None
+                return await self._fallback_session.async_get_vpn_connections()
             return await self._hass.async_add_executor_job(
                 self._get_vpn_connections_sync
             )
         except RequestsTimeout as err:
+            self.invalidate_session()
             raise TimeoutError(str(err)) from err
         except RequestsConnectionError as err:
             if self._use_tls:
@@ -174,6 +180,7 @@ class FritzConnectionVPNSession:
                 return await self._hass.async_add_executor_job(
                     self._get_vpn_connections_sync
                 )
+            self.invalidate_session()
             raise ConnectionError(f"failed to get login page: {err}") from err
         except Exception as err:
             if self._is_fritz_authorization_error(err):
@@ -183,15 +190,18 @@ class FritzConnectionVPNSession:
 
     async def async_toggle_vpn(self, connection_uid: str, enable: bool) -> bool:
         """Toggle VPN on/off with HTTPS->HTTP fallback and auth propagation."""
-        await self._hass.async_add_executor_job(self._ensure_client)
-        if self._mode == "fritzboxvpn":
-            assert self._fallback_session is not None
-            return await self._fallback_session.async_toggle_vpn(connection_uid, enable)
         try:
+            await self._hass.async_add_executor_job(self._ensure_client)
+            if self._mode == "fritzboxvpn":
+                assert self._fallback_session is not None
+                return await self._fallback_session.async_toggle_vpn(
+                    connection_uid, enable
+                )
             return await self._hass.async_add_executor_job(
                 self._toggle_vpn_sync, connection_uid, enable
             )
         except RequestsTimeout as err:
+            self.invalidate_session()
             raise TimeoutError(str(err)) from err
         except RequestsConnectionError as err:
             if self._use_tls:
@@ -205,6 +215,7 @@ class FritzConnectionVPNSession:
                 return await self._hass.async_add_executor_job(
                     self._toggle_vpn_sync, connection_uid, enable
                 )
+            self.invalidate_session()
             raise ConnectionError(f"failed to toggle VPN: {err}") from err
         except Exception as err:
             if self._is_fritz_authorization_error(err):

--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -10,7 +10,7 @@
   "issue_tracker": "https://github.com/rosch100/fritzbox-vpn/issues",
   "loggers": ["fritzboxvpn"],
   "quality_scale": "gold",
-  "requirements": ["fritzboxvpn==1.0.0", "fritzconnection"],
+  "requirements": ["fritzboxvpn==1.0.1", "fritzconnection"],
   "ssdp": [
     {
       "st": "urn:schemas-upnp-org:device:fritzbox:1"

--- a/fritzboxvpn/fritzboxvpn/session.py
+++ b/fritzboxvpn/fritzboxvpn/session.py
@@ -271,8 +271,10 @@ class FritzBoxVPNSession:
             if response.status == HTTP_STATUS_FORBIDDEN:
                 raise ValueError(ERROR_MSG_INVALID_SID_403)
             if response.status != HTTP_STATUS_OK:
-                _LOGGER.warning("Failed to get VPN connections: HTTP %d", response.status)
-                return {}
+                self.invalidate_session()
+                raise ConnectionError(
+                    f"Failed to get VPN connections: HTTP {response.status}"
+                )
 
             content_type = (response.headers.get("Content-Type") or "").lower()
             if CONTENT_TYPE_JSON not in content_type:
@@ -286,7 +288,12 @@ class FritzBoxVPNSession:
             box = extract_box_connections_from_data(data, API_PAGE_SHAREWIREGUARD)
             if box is not None:
                 return normalize_box_connections(box)
-            return {}
+            # Missing boxConnections is typical while the box is rebooting or the
+            # cached SID/protocol is stale — do not soft-succeed with {}.
+            self.invalidate_session()
+            raise ConnectionError(
+                "VPN connections payload missing from Fritz!Box response"
+            )
 
     async def async_get_vpn_connections(self) -> dict[str, Any]:
         """WireGuard VPN connections; cached session, retry once on SID expiry."""
@@ -393,9 +400,14 @@ class FritzBoxVPNSession:
             return False
 
     def invalidate_session(self) -> None:
-        """Invalidate cached SID so next request performs new login."""
+        """Invalidate cached SID and reset protocol so the next request re-logins.
+
+        Protocol is reset to HTTPS because a temporary reboot outage can flip
+        HTTPS→HTTP permanently for the lifetime of this session object.
+        """
         self.sid = None
+        self.protocol = DEFAULT_PROTOCOL
 
     async def async_close(self) -> None:
-        """Clear cached SID."""
-        self.sid = None
+        """Clear cached SID and reset protocol."""
+        self.invalidate_session()

--- a/fritzboxvpn/pyproject.toml
+++ b/fritzboxvpn/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fritzboxvpn"
-version = "1.0.0"
+version = "1.0.1"
 description = "Async Python library for AVM Fritz!Box WireGuard VPN Web API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_coordinator_session.py
+++ b/tests/test_coordinator_session.py
@@ -164,7 +164,12 @@ async def test_session_toggle_off_success() -> None:
 @pytest.mark.asyncio
 async def test_session_toggle_unknown_connection() -> None:
     """Toggle returns False when connection UID is missing."""
-    http = QueuedAiohttpSession([*_login_sequence(), json_response({"data": {"init": {}}})])
+    http = QueuedAiohttpSession(
+        [
+            *_login_sequence(),
+            json_response({"data": {"init": {"boxConnections": {}}}}),
+        ]
+    )
     fb = FritzBoxVPNSession(http, MOCK_HOST, MOCK_USERNAME, MOCK_PASSWORD)
     assert await fb.async_toggle_vpn("missing", True) is False
 

--- a/tests/test_fritzconnection_session.py
+++ b/tests/test_fritzconnection_session.py
@@ -51,12 +51,21 @@ def test_ensure_client_passes_timeout_to_fritzconnection() -> None:
 
     fake_fc_cls = MagicMock(return_value=MagicMock())
     fake_fwg_cls = MagicMock(return_value=MagicMock())
-    fake_mod = types.ModuleType("fritzconnection.lib.fritzwireguard")
-    fake_mod.FritzWireguard = fake_fwg_cls
 
-    with (
-        patch.dict(sys.modules, {"fritzconnection.lib.fritzwireguard": fake_mod}),
-        patch("fritzconnection.FritzConnection", fake_fc_cls),
+    # CI test deps do not install fritzconnection; inject stub modules.
+    fc_mod = types.ModuleType("fritzconnection")
+    fc_mod.FritzConnection = fake_fc_cls
+    lib_mod = types.ModuleType("fritzconnection.lib")
+    fwg_mod = types.ModuleType("fritzconnection.lib.fritzwireguard")
+    fwg_mod.FritzWireguard = fake_fwg_cls
+
+    with patch.dict(
+        sys.modules,
+        {
+            "fritzconnection": fc_mod,
+            "fritzconnection.lib": lib_mod,
+            "fritzconnection.lib.fritzwireguard": fwg_mod,
+        },
     ):
         session._ensure_client()
 

--- a/tests/test_fritzconnection_session.py
+++ b/tests/test_fritzconnection_session.py
@@ -1,0 +1,112 @@
+"""Tests for FritzConnectionVPNSession adapter hardening."""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from custom_components.fritzbox_vpn.fritzconnection_session import (
+    FritzConnectionVPNSession,
+)
+from fritzboxvpn.const import DEFAULT_TIMEOUT
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import Timeout as RequestsTimeout
+
+
+@pytest.mark.asyncio
+async def test_async_close_does_not_bootstrap_client() -> None:
+    """Unload must not create a FritzConnection against an unavailable router."""
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *a: fn(*a))
+    session = FritzConnectionVPNSession(hass, "1.2.3.4", "u", "p")
+
+    with patch.object(session, "_ensure_client") as ensure:
+        await session.async_close()
+    ensure.assert_not_called()
+    hass.async_add_executor_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_close_closes_existing_fritzconnection_only() -> None:
+    """Initialized FritzConnection sessions are closed via executor."""
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *a: fn(*a))
+    session = FritzConnectionVPNSession(hass, "1.2.3.4", "u", "p")
+    session._mode = "fritzconnection"
+    fc = MagicMock()
+    session._fc = fc
+    session._fwg = MagicMock()
+
+    await session.async_close()
+    fc.session.close.assert_called_once()
+    assert session._fc is None
+
+
+def test_ensure_client_passes_timeout_to_fritzconnection() -> None:
+    """FritzConnection bootstrap must set a constructor timeout."""
+    hass = MagicMock()
+    session = FritzConnectionVPNSession(hass, "1.2.3.4", "user", "pass", use_tls=True)
+
+    fake_fc_cls = MagicMock(return_value=MagicMock())
+    fake_fwg_cls = MagicMock(return_value=MagicMock())
+    fake_mod = types.ModuleType("fritzconnection.lib.fritzwireguard")
+    fake_mod.FritzWireguard = fake_fwg_cls
+
+    with (
+        patch.dict(sys.modules, {"fritzconnection.lib.fritzwireguard": fake_mod}),
+        patch("fritzconnection.FritzConnection", fake_fc_cls),
+    ):
+        session._ensure_client()
+
+    fake_fc_cls.assert_called_once_with(
+        address="1.2.3.4",
+        user="user",
+        password="pass",
+        timeout=float(DEFAULT_TIMEOUT),
+        use_tls=True,
+    )
+    assert session._mode == "fritzconnection"
+
+
+@pytest.mark.asyncio
+async def test_get_vpn_connections_maps_bootstrap_timeout() -> None:
+    """Discovery timeouts during ensure_client become TimeoutError."""
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock(side_effect=RequestsTimeout("slow"))
+    session = FritzConnectionVPNSession(hass, "1.2.3.4", "u", "p")
+
+    with pytest.raises(TimeoutError, match="slow"):
+        await session.async_get_vpn_connections()
+
+
+@pytest.mark.asyncio
+async def test_get_vpn_connections_https_fallback_on_bootstrap_connection_error() -> (
+    None
+):
+    """Connection errors during bootstrap trigger HTTPS→HTTP retry."""
+    hass = MagicMock()
+    session = FritzConnectionVPNSession(hass, "1.2.3.4", "u", "p", use_tls=True)
+    calls = {"ensure": 0}
+
+    def ensure() -> None:
+        calls["ensure"] += 1
+        if calls["ensure"] == 1:
+            raise RequestsConnectionError("https down")
+        session._mode = "fritzconnection"
+        session._fwg = MagicMock()
+        session._fwg.get_vpn_connections.return_value = {"a": {"uid": "a"}}
+
+    session._ensure_client = ensure  # type: ignore[method-assign]
+    session._close_sync = MagicMock()  # type: ignore[method-assign]
+
+    async def run_job(fn, *args):
+        return fn(*args)
+
+    hass.async_add_executor_job = AsyncMock(side_effect=run_job)
+
+    data = await session.async_get_vpn_connections()
+    assert data == {"a": {"uid": "a"}}
+    assert session._use_tls is False
+    assert calls["ensure"] >= 2

--- a/tests/test_safe_entity_id_suffix_repair.py
+++ b/tests/test_safe_entity_id_suffix_repair.py
@@ -1,0 +1,74 @@
+"""Regression tests for non-destructive numeric entity_id repair (#37)."""
+
+from __future__ import annotations
+
+import pytest
+from custom_components.fritzbox_vpn import _repair_entity_ids_before_platform_setup
+from custom_components.fritzbox_vpn.const import DOMAIN, UNIQUE_ID_PREFIX
+from custom_components.fritzbox_vpn.entity_registry import (
+    get_entity_id_suffix_repairs,
+    repair_entity_id_suffixes,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+
+@pytest.mark.asyncio
+async def test_auto_repair_does_not_replace_existing_base(hass: HomeAssistant) -> None:
+    """When base entity_id exists, setup repair must not delete/rename over it."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"})
+    entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+
+    base = registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}vpn1_connected",
+        suggested_object_id="office_vpn_connected",
+        config_entry=entry,
+    )
+    suffixed = registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}vpn1b_connected",
+        suggested_object_id="office_vpn_connected_2",
+        config_entry=entry,
+    )
+    assert base.entity_id == "binary_sensor.office_vpn_connected"
+    assert suffixed.entity_id == "binary_sensor.office_vpn_connected_2"
+
+    repairs = get_entity_id_suffix_repairs(
+        registry, entry.entry_id, allow_replace_base=False
+    )
+    assert repairs == []
+
+    repaired = _repair_entity_ids_before_platform_setup(hass, entry.entry_id)
+    assert repaired == 0
+    assert registry.async_get(base.entity_id) is not None
+    assert registry.async_get(suffixed.entity_id) is not None
+    assert registry.async_get(base.entity_id).unique_id == (
+        f"{UNIQUE_ID_PREFIX}vpn1_connected"
+    )
+
+
+@pytest.mark.asyncio
+async def test_repair_renames_when_base_is_free(hass: HomeAssistant) -> None:
+    """Numeric suffix may be renamed to base when the base entity_id is unused."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"})
+    entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    suffixed = registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}vpn1_switch",
+        suggested_object_id="office_vpn_2",
+        config_entry=entry,
+    )
+    assert suffixed.entity_id.endswith("_2")
+
+    count, messages = repair_entity_id_suffixes(hass, entry.entry_id)
+    assert count == 1
+    assert messages
+    assert registry.async_get("switch.office_vpn") is not None
+    assert registry.async_get(suffixed.entity_id) is None

--- a/tests/test_safe_entity_id_suffix_repair.py
+++ b/tests/test_safe_entity_id_suffix_repair.py
@@ -72,3 +72,40 @@ async def test_repair_renames_when_base_is_free(hass: HomeAssistant) -> None:
     assert messages
     assert registry.async_get("switch.office_vpn") is not None
     assert registry.async_get(suffixed.entity_id) is None
+
+
+@pytest.mark.asyncio
+async def test_repair_allow_replace_base_removes_base_then_renames(
+    hass: HomeAssistant,
+) -> None:
+    """Opt-in allow_replace_base=True reassigns base ID to the suffixed entry."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"})
+    entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+
+    base = registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}vpn_old_switch",
+        suggested_object_id="office_vpn",
+        config_entry=entry,
+    )
+    suffixed = registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}vpn_new_switch",
+        suggested_object_id="office_vpn_2",
+        config_entry=entry,
+    )
+    assert base.entity_id == "switch.office_vpn"
+    assert suffixed.entity_id == "switch.office_vpn_2"
+    suffixed_unique_id = suffixed.unique_id
+
+    count, _messages = repair_entity_id_suffixes(
+        hass, entry.entry_id, allow_replace_base=True
+    )
+    assert count == 1
+    assert registry.async_get("switch.office_vpn_2") is None
+    replaced = registry.async_get("switch.office_vpn")
+    assert replaced is not None
+    assert replaced.unique_id == suffixed_unique_id

--- a/tests/test_session_reboot_recovery.py
+++ b/tests/test_session_reboot_recovery.py
@@ -1,0 +1,139 @@
+"""Regression tests for Fritz!Box reboot / session recovery (#42)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from custom_components.fritzbox_vpn.coordinator import FritzBoxVPNCoordinator
+from fritzboxvpn import FritzBoxVPNSession
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from tests.aiohttp_mock import MockAiohttpResponse, QueuedAiohttpSession, json_response
+from tests.fixtures import (
+    LOGIN_XML_CHALLENGE,
+    LOGIN_XML_SID,
+    MOCK_DATA_LUA_JSON,
+    MOCK_HOST,
+    MOCK_PASSWORD,
+    MOCK_USERNAME,
+)
+
+
+def _login_sequence() -> list[MockAiohttpResponse]:
+    return [
+        MockAiohttpResponse(200, text=LOGIN_XML_CHALLENGE),
+        MockAiohttpResponse(200, text=LOGIN_XML_CHALLENGE),
+        MockAiohttpResponse(200, text=LOGIN_XML_SID),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_non_ok_vpn_fetch_invalidates_session_and_raises() -> None:
+    """HTTP 502 on data.lua must not soft-succeed with {} and keep a stale SID."""
+    http = QueuedAiohttpSession(
+        [
+            *_login_sequence(),
+            MockAiohttpResponse(502, text="bad gateway"),
+        ]
+    )
+    fb = FritzBoxVPNSession(http, MOCK_HOST, MOCK_USERNAME, MOCK_PASSWORD)
+    with pytest.raises(ConnectionError, match="502"):
+        await fb.async_get_vpn_connections()
+    assert fb.sid is None
+    assert fb.protocol == "https"
+
+
+@pytest.mark.asyncio
+async def test_invalidate_session_resets_protocol_to_https() -> None:
+    """Sticky HTTP fallback must be cleared so reboot recovery retries HTTPS."""
+    fb = FritzBoxVPNSession(
+        QueuedAiohttpSession([]), MOCK_HOST, MOCK_USERNAME, MOCK_PASSWORD
+    )
+    fb.sid = "stale"
+    fb.protocol = "http"
+    fb.invalidate_session()
+    assert fb.sid is None
+    assert fb.protocol == "https"
+
+
+@pytest.mark.asyncio
+async def test_reboot_outage_then_recover_without_reload() -> None:
+    """After 502 outage, next poll can re-login and return VPN data again."""
+    http = QueuedAiohttpSession(
+        [
+            *_login_sequence(),
+            MockAiohttpResponse(502, text="bad gateway"),
+            *_login_sequence(),
+            json_response(MOCK_DATA_LUA_JSON),
+        ]
+    )
+    fb = FritzBoxVPNSession(http, MOCK_HOST, MOCK_USERNAME, MOCK_PASSWORD)
+    with pytest.raises(ConnectionError):
+        await fb.async_get_vpn_connections()
+    connections = await fb.async_get_vpn_connections()
+    assert "conn-abc" in connections
+
+
+@pytest.mark.asyncio
+async def test_coordinator_sid_expiry_does_not_schedule_reauth(
+    hass,
+) -> None:
+    """Session-expiry 'Invalid SID' is not a credential failure."""
+    coordinator = FritzBoxVPNCoordinator(
+        hass,
+        {"host": MOCK_HOST, "username": "u", "password": "p"},
+        None,
+        "entry-1",
+    )
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        side_effect=ValueError("Invalid SID (HTTP 403)")
+    )
+    with (
+        patch.object(coordinator, "_schedule_reauth") as schedule_reauth,
+        pytest.raises(UpdateFailed) as exc_info,
+    ):
+        await coordinator._async_update_data()
+    schedule_reauth.assert_not_called()
+    assert exc_info.value.retry_after is not None
+
+
+@pytest.mark.asyncio
+async def test_coordinator_login_failed_still_schedules_reauth(hass) -> None:
+    """Real credential failures still start reauth."""
+    coordinator = FritzBoxVPNCoordinator(
+        hass,
+        {"host": MOCK_HOST, "username": "u", "password": "p"},
+        None,
+        "entry-1",
+    )
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        side_effect=ValueError("Login failed: Invalid SID")
+    )
+    mock_entry = MagicMock()
+    mock_entry.async_start_reauth = AsyncMock()
+    from homeassistant.config_entries import ConfigEntryState
+
+    mock_entry.state = ConfigEntryState.LOADED
+    hass.async_create_task = MagicMock()
+    with (
+        patch.object(hass.config_entries, "async_get_entry", return_value=mock_entry),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_update_data()
+    hass.async_create_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_box_connections_invalidates_and_raises() -> None:
+    """JSON without boxConnections is treated as outage, not empty success."""
+    http = QueuedAiohttpSession(
+        [
+            *_login_sequence(),
+            json_response({"data": {"init": {"other": True}}}),
+        ]
+    )
+    fb = FritzBoxVPNSession(http, MOCK_HOST, MOCK_USERNAME, MOCK_PASSWORD)
+    with pytest.raises(ConnectionError, match="payload missing"):
+        await fb.async_get_vpn_connections()
+    assert fb.sid is None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Behebt zwei zusammenhängende Probleme aus den offenen Issues:

1. **#42 – Entities bleiben nach Router-Reboot unavailable**  
   Soft-Success `{}` / sticky HTTP vermieden; SID+Protokoll invalidieren; Session-Expiry ≠ Credential-Reauth.  
   Adapter: `invalidate_session()`, `async_close` ohne Bootstrap, `FritzConnection(..., timeout=…)`, Discovery im Error-Guard.

2. **#37 Residual – `_2`-Churn / Recorder-Warnungen**  
   Auto-Repair nur wenn Basis-ID frei (`allow_replace_base=False`). Opt-in destruktiv dokumentiert + getestet.

Library-Bump: `fritzboxvpn` **1.0.0 → 1.0.1**.

CodeRabbit-Findings (M1/M2/N1/N2) sind umgesetzt. Pre-merge „Out of Scope“-Warning bewusst belassen (Scope = #42+#37).

## Test plan

- [x] Lokal: `ruff` + `pytest` (177 passed)
- [ ] CI grün
- [ ] Optional manuell: Reboot ohne Reload; Reload ohne `_2`-Churn

## Checklist

- [ ] Copilot / CodeRabbit Review
- [x] Keine Secrets
- [x] SSDP unverändert
- [x] Integration-`version` nicht angehoben

Fixes #42  
Related #37
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb44a-cca9-7e3d-9cf4-cff3a6b59c26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb44a-cca9-7e3d-9cf4-cff3a6b59c26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery after Fritz!Box reboots, temporary outages, and connection timeouts.
  - Failed or incomplete VPN responses now trigger a clean session refresh instead of appearing as empty data.
  - Session expiry is handled without incorrectly reporting invalid credentials.
  - Correct login failures continue to prompt authentication again.
  - Entity ID repairs are now safer and avoid replacing existing entities unexpectedly.

- **Improvements**
  - Connections retry using HTTPS after temporary protocol fallback issues.
  - Added safeguards for VPN toggle and status updates during Fritz!Box disruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->