### PR TITLE
ci: Workflows an HA Core / HACS Best Practices angleichen

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,7 +39,7 @@ Prefer suggestions over nits for line length in legacy files (Ruff ignores `E501
 
 ## CI expectations
 
-PRs should pass the **CI** workflow jobs: `Ruff`, `pytest`, `HACS validate`, `hassfest`.
+PRs should pass the **CI** workflow jobs: `CI` (aggregate), `Ruff`, `pytest`, `HACS validate`, `hassfest`.
 
 Also: Actionlint (workflow changes), Dependency review (requirements/manifest), CodeQL via GitHub default setup.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 ## Test plan
 
-- [ ] CI grün (`Ruff`, `pytest`, `HACS validate`, `hassfest`) bzw. lokal: `ruff check` + `pytest tests/ --cov -q`
+- [ ] CI grün (`CI` / `Ruff`, `pytest`, `HACS validate`, `hassfest`) bzw. lokal: `ruff check` + `ruff format --check` + `pytest tests/ --cov -q`
 - [ ] Bei SSDP/`config_flow`: `tests/test_ssdp_unique_id.py` und `tests/test_config_flow_ssdp.py`
 - [ ] Bei Manifest/Strings: HACS- und hassfest-Workflow beachtet
 

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -9,7 +9,7 @@
 `required-ci.json` – Schutz für **`main`**:
 
 1. **Pull Request erforderlich** (0 Approvals) – kein direkter Push auf `main`
-2. **Pflicht-Checks:** `Ruff`, `pytest`, `HACS validate`, `hassfest` (Workflow **CI**)
+2. **Pflicht-Checks:** `Ruff`, `pytest`, `HACS validate`, `hassfest` (Workflow **CI**; zusätzlich Aggregate-Job `CI`)
 
 Ruleset-ID: **16545012** – [Einstellungen](https://github.com/rosch100/fritzbox-vpn/rules/16545012)
 

--- a/.github/rulesets/required-ci.json
+++ b/.github/rulesets/required-ci.json
@@ -26,6 +26,7 @@
         "strict_required_status_checks_policy": false,
         "do_not_enforce_on_create": true,
         "required_status_checks": [
+          { "context": "CI" },
           { "context": "Ruff" },
           { "context": "pytest" },
           { "context": "HACS validate" },

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,5 +1,6 @@
 name: Actionlint
 
+# yamllint disable-line rule:truthy
 on:
   push:
     branches:
@@ -14,21 +15,30 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: actionlint-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   actionlint:
     name: Lint workflows
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - name: Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install and run actionlint
+        env:
+          # Pin actionlint release for reproducible CI (same idea as HA Core pins).
+          ACTIONLINT_VERSION: 1.7.12
         run: |
-          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          set -euo pipefail
+          bash <(curl -fsSL "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash") \
+            "${ACTIONLINT_VERSION}"
           ./actionlint -color

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,66 +1,92 @@
-# Unified CI: lint, tests, HACS, hassfest (same triggers, consistent PR checks)
+# CI aligned with home-assistant/core and hacs/integration practices:
+# - workflow-level permissions: {} (least privilege; grant per job)
+# - actions pinned by commit SHA with version comments
+# - persist-credentials: false on checkout
+# - concurrency keyed by PR number
+# - ubuntu-24.04, job timeouts, workflow_dispatch inputs
+# - required check names preserved for ruleset: Ruff, pytest, HACS validate, hassfest
 name: CI
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch'
+      && format('CI: {0}', github.ref_name)
+      || '' }}
 
+# yamllint disable-line rule:truthy
 on:
   push:
     branches:
       - main
-    paths: &ci-paths
-      - "custom_components/**"
-      - "fritzboxvpn/**"
-      - "tests/**"
-      - "scripts/**"
-      - "docs/releases/**"
-      - "hacs.json"
-      - "pytest.ini"
-      - ".coveragerc"
-      - "pyproject.toml"
-      - ".pre-commit-config.yaml"
-      - ".github/workflows/ci.yml"
-      - ".github/workflows/publish-pypi.yml"
-      - ".github/rulesets/**"
-      - ".github/instructions/**"
-      - ".github/copilot-instructions.md"
-      - "AGENTS.md"
   pull_request:
-    paths: *ci-paths
   schedule:
     # Nightly HACS/hassfest even without code changes
     - cron: "0 0 * * *"
   workflow_dispatch:
+    inputs:
+      lint-only:
+        description: Skip pytest (lint + validate only)
+        default: false
+        type: boolean
+      skip-coverage:
+        description: Skip coverage reporting/fail-under
+        default: false
+        type: boolean
+
+env:
+  PYTHON_VERSION: "3.13"
+  RUFF_OUTPUT_FORMAT: github
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  pull-requests: write
+# Empty top-level permissions; each job declares the minimum it needs.
+permissions: {}
 
 jobs:
   ruff:
     name: Ruff
     if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: astral-sh/ruff-action@v3
+      - name: Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
+
+      - name: Run Ruff check
+        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
+        with:
+          args: check
+          src: custom_components tests fritzboxvpn/fritzboxvpn
+
+      - name: Run Ruff format check
+        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
+        with:
+          args: format --check
           src: custom_components tests fritzboxvpn/fritzboxvpn
 
   pytest:
     name: pytest
-    if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
+    if: |
+      github.event_name != 'schedule'
+      && github.event.inputs.lint-only != 'true'
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-python@v6
+      - name: Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          python-version: "3.13"
+          persist-credentials: false
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
           cache-dependency-path: scripts/requirements-test.txt
 
@@ -70,36 +96,92 @@ jobs:
           pip install -r scripts/requirements-test.txt
 
       - name: Run tests with coverage
+        if: github.event.inputs.skip-coverage != 'true'
         run: pytest tests/ --cov --cov-report=term-missing -q
+
+      - name: Run tests without coverage
+        if: github.event.inputs.skip-coverage == 'true'
+        run: pytest tests/ -q
 
   hacs:
     name: HACS validate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
+    permissions:
+      contents: read
+      # hacs/action may post a PR comment when comment: true
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - name: Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # GitHub's license detection can lag behind for PRs; for PRs we ignore
       # only the license check to avoid blocking CI until the default branch
       # metadata is updated.
-      - uses: hacs/action@22.5.0
+      - name: HACS validation (pull request)
         if: github.event_name == 'pull_request'
+        uses: hacs/action@d556e736723344f83838d08488c983a15381059a # 22.5.0
         with:
           category: integration
           comment: true
           ignore: license
 
-      - uses: hacs/action@22.5.0
+      - name: HACS validation
         if: github.event_name != 'pull_request'
+        uses: hacs/action@d556e736723344f83838d08488c983a15381059a # 22.5.0
         with:
           category: integration
           comment: false
 
   hassfest:
     name: hassfest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - name: Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: home-assistant/actions/hassfest@master
+      - name: Run hassfest
+        uses: home-assistant/actions/hassfest@ab22029681aa532bfe7de5774a9972d67bfbd2c0 # master
+
+  # Single gate for humans/agents; individual jobs stay required in ruleset.
+  ci:
+    name: CI
+    if: always()
+    needs:
+      - ruff
+      - pytest
+      - hacs
+      - hassfest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Check job results
+        env:
+          RUFF: ${{ needs.ruff.result }}
+          PYTEST: ${{ needs.pytest.result }}
+          HACS: ${{ needs.hacs.result }}
+          HASSFEST: ${{ needs.hassfest.result }}
+        run: |
+          set -euo pipefail
+          failed=0
+          for name_result in "ruff:${RUFF}" "pytest:${PYTEST}" "hacs:${HACS}" "hassfest:${HASSFEST}"; do
+            name="${name_result%%:*}"
+            result="${name_result##*:}"
+            echo "${name}=${result}"
+            case "${result}" in
+              success|skipped) ;;
+              *)
+                echo "::error::Required job '${name}' finished with '${result}'"
+                failed=1
+                ;;
+            esac
+          done
+          exit "${failed}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,26 +1,31 @@
 name: Dependency review
 
+# yamllint disable-line rule:truthy
 on:
   pull_request:
-    paths:
-      - "scripts/requirements-test.txt"
-      - "custom_components/**/manifest.json"
-      - ".github/workflows/**"
-      - ".github/dependabot.yml"
 
-permissions:
-  contents: read
-  pull-requests: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   dependency-review:
     name: Review dependencies
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - name: Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: actions/dependency-review-action@v4
+      - name: Dependency review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
           comment-summary-in-pr: always

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ python3 -m venv .venv
 .venv/bin/pytest tests/ --cov=custom_components/fritzbox_vpn -q
 ```
 
-Vor Merge: CI-Jobs `Ruff`, `pytest`, `HACS validate`, `hassfest`.
+Vor Merge: CI-Jobs `Ruff`, `pytest`, `HACS validate`, `hassfest` (Aggregate-Check `CI`).
 
 ## Core-Vorbereitung
 

--- a/custom_components/fritzbox_vpn/__init__.py
+++ b/custom_components/fritzbox_vpn/__init__.py
@@ -183,7 +183,9 @@ def _repair_entity_ids_before_platform_setup(hass: HomeAssistant, entry_id: str)
     return repaired_count
 
 
-async def async_migrate_entry(hass: HomeAssistant, entry: FritzboxVpnConfigEntry) -> bool:
+async def async_migrate_entry(
+    hass: HomeAssistant, entry: FritzboxVpnConfigEntry
+) -> bool:
     """Run one-time migrations for config entries."""
     if entry.version < 2:
         count, _ = repair_legacy_entity_object_ids(hass, entry.entry_id)

--- a/custom_components/fritzbox_vpn/config_flow.py
+++ b/custom_components/fritzbox_vpn/config_flow.py
@@ -76,7 +76,9 @@ async def _try_create_entry_from_credentials(
     try:
         info = await flow_forms.validate_input(hass, user_input)
     except Exception as err:
-        flow_forms.set_validation_error(errors, err, log_unknown_details=log_unknown_details)
+        flow_forms.set_validation_error(
+            errors, err, log_unknown_details=log_unknown_details
+        )
         return None
     if unique_id is not None:
         await flow.async_set_unique_id(unique_id)
@@ -107,7 +109,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 has_password = bool(password_from_sources(self._existing_config))
                 if has_host and has_username and has_password:
                     try:
-                        info = await flow_forms.validate_input(self.hass, self._existing_config)
+                        info = await flow_forms.validate_input(
+                            self.hass, self._existing_config
+                        )
                         return self.async_create_entry(
                             title=info["title"], data=self._existing_config
                         )
@@ -146,7 +150,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
         if result is not None:
             return result
-        schema = flow_forms.credentials_schema(*flow_forms.credentials_defaults(user_input))
+        schema = flow_forms.credentials_schema(
+            *flow_forms.credentials_defaults(user_input)
+        )
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
 
     async def async_step_ssdp(self, discovery_info: SsdpServiceInfo) -> FlowResult:
@@ -252,7 +258,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reauth_confirm",
-            data_schema=flow_forms.reauth_schema(user_input.get(CONF_USERNAME, username_default)),
+            data_schema=flow_forms.reauth_schema(
+                user_input.get(CONF_USERNAME, username_default)
+            ),
             description_placeholders={"host": host},
             errors=errors,
         )
@@ -282,8 +290,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors,
             reconfigure_entry.data or {},
         ):
-            config_data, options_data = flow_forms.config_and_options_from_configure_input(
-                user_input
+            config_data, options_data = (
+                flow_forms.config_and_options_from_configure_input(user_input)
             )
             return self.async_update_reload_and_abort(
                 reconfigure_entry,
@@ -485,8 +493,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             errors,
             config_entry.data or {},
         ):
-            config_data, options_data = flow_forms.config_and_options_from_configure_input(
-                user_input
+            config_data, options_data = (
+                flow_forms.config_and_options_from_configure_input(user_input)
             )
             self.hass.config_entries.async_update_entry(
                 config_entry,

--- a/custom_components/fritzbox_vpn/const.py
+++ b/custom_components/fritzbox_vpn/const.py
@@ -43,12 +43,8 @@ SERVICE_REMOVE_UNAVAILABLE_ENTITIES = "remove_unavailable_entities"
 SERVICE_REPAIR_ENTITY_ID_SUFFIXES = "repair_entity_id_suffixes"
 CONF_CONFIG_ENTRY_ID = "config_entry_id"
 
-LOG_MSG_VPN_CONNECTIONS_REMOVED = (
-    "VPN connection(s) no longer available on the %s; related entities will show as unavailable: %s"
-)
-LOG_MSG_VPN_CONNECTIONS_REMOVED_HINT = (
-    "You can remove obsolete entities under Settings > Devices & Services > Entities (filter by Fritz!Box VPN)."
-)
+LOG_MSG_VPN_CONNECTIONS_REMOVED = "VPN connection(s) no longer available on the %s; related entities will show as unavailable: %s"
+LOG_MSG_VPN_CONNECTIONS_REMOVED_HINT = "You can remove obsolete entities under Settings > Devices & Services > Entities (filter by Fritz!Box VPN)."
 
 MANUFACTURER_AVM = "AVM"
 MODEL_FRITZBOX = "Fritz!Box"
@@ -84,7 +80,9 @@ def password_from_source(source: Mapping[str, Any] | None) -> str:
     """Return password from one dict (CONF_PASSWORD, 'password', or 'pass'), or empty string."""
     if not source:
         return ""
-    return str(source.get(CONF_PASSWORD) or source.get("password") or source.get("pass") or "")
+    return str(
+        source.get(CONF_PASSWORD) or source.get("password") or source.get("pass") or ""
+    )
 
 
 def password_from_sources(*sources: Mapping[str, Any] | None) -> str:
@@ -116,7 +114,12 @@ FRITZBOX_SSDP_INDICATORS = (
     "fritz",
 )
 
-FRITZ_INTEGRATION_DOMAINS = ("fritz", "fritzbox_tools", "fritzbox", "fritzbox_tools_plus")
+FRITZ_INTEGRATION_DOMAINS = (
+    "fritz",
+    "fritzbox_tools",
+    "fritzbox",
+    "fritzbox_tools_plus",
+)
 SENSITIVE_CONFIG_KEYS = ("password", "pass", "username", "user")
 
 REPEATER_INDICATORS = (

--- a/custom_components/fritzbox_vpn/entity_registry.py
+++ b/custom_components/fritzbox_vpn/entity_registry.py
@@ -43,7 +43,9 @@ def connection_uid_from_entity_unique_id(unique_id: str) -> str | None:
     return rest[: -len(suffix) - 1]
 
 
-def expected_object_id_for_device_suffix(device_name: str, unique_id_suffix: str) -> str:
+def expected_object_id_for_device_suffix(
+    device_name: str, unique_id_suffix: str
+) -> str:
     """Stable object_id slug for a VPN device name and platform suffix."""
     if unique_id_suffix == UNIQUE_ID_SUFFIX_SWITCH:
         return slugify(device_name)

--- a/custom_components/fritzbox_vpn/fritz_config_source.py
+++ b/custom_components/fritzbox_vpn/fritz_config_source.py
@@ -27,14 +27,20 @@ def _entry_has_credentials(entry: config_entries.ConfigEntry) -> bool:
     return bool(password_from_sources(data, options))
 
 
-def _host_username_password_from_entry(entry: config_entries.ConfigEntry) -> dict[str, Any] | None:
+def _host_username_password_from_entry(
+    entry: config_entries.ConfigEntry,
+) -> dict[str, Any] | None:
     """Host, username, password from entry; None if no host."""
     config_data = entry.data or {}
     options_data = entry.options or {}
     host = (
         config_data.get(CONF_HOST)
         or config_data.get("host")
-        or (config_data.get("hosts", [None])[0] if isinstance(config_data.get("hosts"), list) and config_data.get("hosts") else None)
+        or (
+            config_data.get("hosts", [None])[0]
+            if isinstance(config_data.get("hosts"), list) and config_data.get("hosts")
+            else None
+        )
         or config_data.get("hostname")
         or config_data.get("ip_address")
         or options_data.get(CONF_HOST)
@@ -56,7 +62,11 @@ def _host_username_password_from_entry(entry: config_entries.ConfigEntry) -> dic
         password = password or password_from_sources(nested)
     if not host:
         return None
-    return {CONF_HOST: host, CONF_USERNAME: username or "", CONF_PASSWORD: password or ""}
+    return {
+        CONF_HOST: host,
+        CONF_USERNAME: username or "",
+        CONF_PASSWORD: password or "",
+    }
 
 
 async def get_existing_fritz_config(hass: HomeAssistant) -> dict[str, Any] | None:
@@ -76,14 +86,17 @@ async def get_existing_fritz_config(hass: HomeAssistant) -> dict[str, Any] | Non
             continue
 
         router_entries = [
-            e for e in entries
+            e
+            for e in entries
             if not any(ind in (e.title or "").lower() for ind in REPEATER_INDICATORS)
         ]
         if not router_entries:
             continue
 
         try:
-            entries_with_creds = [e for e in router_entries if _entry_has_credentials(e)]
+            entries_with_creds = [
+                e for e in router_entries if _entry_has_credentials(e)
+            ]
             entry = entries_with_creds[0] if entries_with_creds else router_entries[0]
             result = _host_username_password_from_entry(entry)
             if result:

--- a/fritzboxvpn/fritzboxvpn/parsing.py
+++ b/fritzboxvpn/fritzboxvpn/parsing.py
@@ -136,9 +136,7 @@ def describe_json_value(value: Any, *, max_keys: int = 20) -> dict[str, Any]:
     return {"type": type(value).__name__}
 
 
-def extract_box_connections_from_data(
-    data: dict[str, Any], page: str
-) -> Any:
+def extract_box_connections_from_data(data: dict[str, Any], page: str) -> Any:
     """Extract boxConnections from data.lua JSON (WireGuard page)."""
     if not isinstance(data, dict):
         return None

--- a/fritzboxvpn/fritzboxvpn/session.py
+++ b/fritzboxvpn/fritzboxvpn/session.py
@@ -197,7 +197,9 @@ class FritzBoxVPNSession:
 
         return f"{salt2_hex}${hash2.hex()}"
 
-    async def _fetch_login_page(self, login_url: str, timeout: ClientTimeout) -> str | None:
+    async def _fetch_login_page(
+        self, login_url: str, timeout: ClientTimeout
+    ) -> str | None:
         """GET login page; HTTPS→HTTP fallback. Returns content or None."""
         parsed = urlsplit(login_url)
         api_path = parsed.path
@@ -241,8 +243,7 @@ class FritzBoxVPNSession:
             )
             self.protocol = PROTOCOL_HTTP
             login_url = (
-                f"{self.protocol}://{self.host}{api_path}"
-                f"{'?' + query if query else ''}"
+                f"{self.protocol}://{self.host}{api_path}{'?' + query if query else ''}"
             )
             async with self.session.get(
                 login_url, ssl=False, timeout=timeout
@@ -271,7 +272,9 @@ class FritzBoxVPNSession:
             if response.status == HTTP_STATUS_FORBIDDEN:
                 raise ValueError(ERROR_MSG_INVALID_SID_403)
             if response.status != HTTP_STATUS_OK:
-                _LOGGER.warning("Failed to get VPN connections: HTTP %d", response.status)
+                _LOGGER.warning(
+                    "Failed to get VPN connections: HTTP %d", response.status
+                )
                 return {}
 
             content_type = (response.headers.get("Content-Type") or "").lower()

--- a/scripts/requirements-test.txt
+++ b/scripts/requirements-test.txt
@@ -1,4 +1,4 @@
-# Test dependencies (see .github/workflows/ci.yml)
+# Test dependencies (see .github/workflows/ci.yml — Python 3.13)
 # Pin to minimum HA from hacs.json / manifest (2026.1.0)
 -e ./fritzboxvpn
 aiohttp>=3.8.0

--- a/tests/aiohttp_mock.py
+++ b/tests/aiohttp_mock.py
@@ -43,9 +43,7 @@ class QueuedAiohttpSession:
         try:
             return next(self._responses)
         except StopIteration as err:
-            raise AssertionError(
-                f"No mock response left for {method} {url}"
-            ) from err
+            raise AssertionError(f"No mock response left for {method} {url}") from err
 
     def get(self, url: str, **kwargs: Any) -> MockAiohttpResponse:
         return self._dequeue("GET", url, **kwargs)

--- a/tests/test_auto_shadow_entity_cleanup.py
+++ b/tests/test_auto_shadow_entity_cleanup.py
@@ -31,9 +31,7 @@ async def test_shadow_entities_removed_on_setup(
         config_entry=mock_config_entry,
     )
 
-    before = er.async_entries_for_config_entry(
-        registry, mock_config_entry.entry_id
-    )
+    before = er.async_entries_for_config_entry(registry, mock_config_entry.entry_id)
     assert any((e.unique_id or "") == shadow_unique_id for e in before)
 
     mock_coordinator = MagicMock()
@@ -58,4 +56,3 @@ async def test_shadow_entities_removed_on_setup(
 
     after = er.async_entries_for_config_entry(registry, mock_config_entry.entry_id)
     assert not any((e.unique_id or "") == shadow_unique_id for e in after)
-

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -37,12 +37,15 @@ def test_validate_host_rejects_invalid() -> None:
 @pytest.mark.asyncio
 async def test_user_flow_create_entry(hass: HomeAssistant) -> None:
     """User flow creates config entry after successful validation."""
-    with patch(
-        "custom_components.fritzbox_vpn.config_flow.get_existing_fritz_config",
-        new=AsyncMock(return_value=None),
-    ), patch(
-        "custom_components.fritzbox_vpn.flow_forms.validate_input",
-        new=AsyncMock(return_value={"title": f"Fritz!Box VPN ({MOCK_HOST})"}),
+    with (
+        patch(
+            "custom_components.fritzbox_vpn.config_flow.get_existing_fritz_config",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "custom_components.fritzbox_vpn.flow_forms.validate_input",
+            new=AsyncMock(return_value={"title": f"Fritz!Box VPN ({MOCK_HOST})"}),
+        ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
@@ -66,12 +69,15 @@ async def test_user_flow_create_entry(hass: HomeAssistant) -> None:
 @pytest.mark.asyncio
 async def test_user_flow_invalid_auth(hass: HomeAssistant) -> None:
     """User flow shows invalid_auth when validation fails."""
-    with patch(
-        "custom_components.fritzbox_vpn.config_flow.get_existing_fritz_config",
-        new=AsyncMock(return_value=None),
-    ), patch(
-        "custom_components.fritzbox_vpn.flow_forms.validate_input",
-        new=AsyncMock(side_effect=InvalidAuth),
+    with (
+        patch(
+            "custom_components.fritzbox_vpn.config_flow.get_existing_fritz_config",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "custom_components.fritzbox_vpn.flow_forms.validate_input",
+            new=AsyncMock(side_effect=InvalidAuth),
+        ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
@@ -113,7 +119,9 @@ async def test_user_flow_invalid_host(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.asyncio
-async def test_reauth_updates_credentials(hass: HomeAssistant, mock_config_entry: MockConfigEntry) -> None:
+async def test_reauth_updates_credentials(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
     """Reauth flow updates entry data after successful validation."""
     mock_config_entry.add_to_hass(hass)
 
@@ -140,9 +148,12 @@ async def test_reauth_updates_credentials(hass: HomeAssistant, mock_config_entry
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
-    assert hass.config_entries.async_get_entry(mock_config_entry.entry_id).data[
-        CONF_USERNAME
-    ] == "new-user"
+    assert (
+        hass.config_entries.async_get_entry(mock_config_entry.entry_id).data[
+            CONF_USERNAME
+        ]
+        == "new-user"
+    )
 
 
 @pytest.mark.asyncio
@@ -172,18 +183,21 @@ async def test_validate_input_maps_auth_error(hass: HomeAssistant) -> None:
 @pytest.mark.asyncio
 async def test_user_autoconfig_invalid_auth(hass: HomeAssistant) -> None:
     """User flow shows form with invalid_auth when Fritz autoconfig fails."""
-    with patch(
-        "custom_components.fritzbox_vpn.config_flow.get_existing_fritz_config",
-        new=AsyncMock(
-            return_value={
-                CONF_HOST: MOCK_HOST,
-                CONF_USERNAME: MOCK_USERNAME,
-                CONF_PASSWORD: MOCK_PASSWORD,
-            }
+    with (
+        patch(
+            "custom_components.fritzbox_vpn.config_flow.get_existing_fritz_config",
+            new=AsyncMock(
+                return_value={
+                    CONF_HOST: MOCK_HOST,
+                    CONF_USERNAME: MOCK_USERNAME,
+                    CONF_PASSWORD: MOCK_PASSWORD,
+                }
+            ),
         ),
-    ), patch(
-        "custom_components.fritzbox_vpn.flow_forms.validate_input",
-        new=AsyncMock(side_effect=InvalidAuth),
+        patch(
+            "custom_components.fritzbox_vpn.flow_forms.validate_input",
+            new=AsyncMock(side_effect=InvalidAuth),
+        ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
@@ -196,18 +210,21 @@ async def test_user_autoconfig_invalid_auth(hass: HomeAssistant) -> None:
 @pytest.mark.asyncio
 async def test_user_autoconfig_cannot_connect(hass: HomeAssistant) -> None:
     """User flow shows form with cannot_connect when Fritz autoconfig fails."""
-    with patch(
-        "custom_components.fritzbox_vpn.config_flow.get_existing_fritz_config",
-        new=AsyncMock(
-            return_value={
-                CONF_HOST: MOCK_HOST,
-                CONF_USERNAME: MOCK_USERNAME,
-                CONF_PASSWORD: MOCK_PASSWORD,
-            }
+    with (
+        patch(
+            "custom_components.fritzbox_vpn.config_flow.get_existing_fritz_config",
+            new=AsyncMock(
+                return_value={
+                    CONF_HOST: MOCK_HOST,
+                    CONF_USERNAME: MOCK_USERNAME,
+                    CONF_PASSWORD: MOCK_PASSWORD,
+                }
+            ),
         ),
-    ), patch(
-        "custom_components.fritzbox_vpn.flow_forms.validate_input",
-        new=AsyncMock(side_effect=CannotConnect),
+        patch(
+            "custom_components.fritzbox_vpn.flow_forms.validate_input",
+            new=AsyncMock(side_effect=CannotConnect),
+        ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
@@ -220,18 +237,21 @@ async def test_user_autoconfig_cannot_connect(hass: HomeAssistant) -> None:
 @pytest.mark.asyncio
 async def test_user_autoconfig_unknown_error(hass: HomeAssistant) -> None:
     """User flow shows unknown error when autoconfig raises unexpectedly."""
-    with patch(
-        "custom_components.fritzbox_vpn.config_flow.get_existing_fritz_config",
-        new=AsyncMock(
-            return_value={
-                CONF_HOST: MOCK_HOST,
-                CONF_USERNAME: MOCK_USERNAME,
-                CONF_PASSWORD: MOCK_PASSWORD,
-            }
+    with (
+        patch(
+            "custom_components.fritzbox_vpn.config_flow.get_existing_fritz_config",
+            new=AsyncMock(
+                return_value={
+                    CONF_HOST: MOCK_HOST,
+                    CONF_USERNAME: MOCK_USERNAME,
+                    CONF_PASSWORD: MOCK_PASSWORD,
+                }
+            ),
         ),
-    ), patch(
-        "custom_components.fritzbox_vpn.flow_forms.validate_input",
-        new=AsyncMock(side_effect=RuntimeError("unexpected")),
+        patch(
+            "custom_components.fritzbox_vpn.flow_forms.validate_input",
+            new=AsyncMock(side_effect=RuntimeError("unexpected")),
+        ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
@@ -279,12 +299,15 @@ async def test_reconfigure_updates_entry_without_creating_duplicate(
     mock_config_entry.add_to_hass(hass)
     entries_before = len(hass.config_entries.async_entries(DOMAIN))
 
-    with patch(
-        "custom_components.fritzbox_vpn.flow_forms.validate_input",
-        new=AsyncMock(return_value={"title": mock_config_entry.title}),
-    ), patch.object(
-        hass.config_entries, "async_reload", new=AsyncMock()
-    ) as reload_mock:
+    with (
+        patch(
+            "custom_components.fritzbox_vpn.flow_forms.validate_input",
+            new=AsyncMock(return_value={"title": mock_config_entry.title}),
+        ),
+        patch.object(
+            hass.config_entries, "async_reload", new=AsyncMock()
+        ) as reload_mock,
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={
@@ -349,9 +372,10 @@ async def test_reconfigure_shows_error_on_validation_failure(
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
     assert result["errors"]["base"] == "cannot_connect"
-    assert hass.config_entries.async_get_entry(mock_config_entry.entry_id).data[
-        CONF_HOST
-    ] == mock_config_entry.data[CONF_HOST]
+    assert (
+        hass.config_entries.async_get_entry(mock_config_entry.entry_id).data[CONF_HOST]
+        == mock_config_entry.data[CONF_HOST]
+    )
 
 
 @pytest.mark.asyncio
@@ -362,11 +386,12 @@ async def test_reconfigure_reuses_stored_password_when_empty(
     mock_config_entry.add_to_hass(hass)
     original_password = mock_config_entry.data[CONF_PASSWORD]
 
-    with patch(
-        "custom_components.fritzbox_vpn.flow_forms.validate_input",
-        new=AsyncMock(return_value={"title": mock_config_entry.title}),
-    ) as validate_mock, patch.object(
-        hass.config_entries, "async_reload", new=AsyncMock()
+    with (
+        patch(
+            "custom_components.fritzbox_vpn.flow_forms.validate_input",
+            new=AsyncMock(return_value={"title": mock_config_entry.title}),
+        ) as validate_mock,
+        patch.object(hass.config_entries, "async_reload", new=AsyncMock()),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -28,7 +28,9 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 def test_connection_uid_unknown_suffix() -> None:
     """Unique IDs without known suffix return None."""
-    assert connection_uid_from_entity_unique_id(f"{UNIQUE_ID_PREFIX}abc_unknown") is None
+    assert (
+        connection_uid_from_entity_unique_id(f"{UNIQUE_ID_PREFIX}abc_unknown") is None
+    )
 
 
 def test_connection_uid_from_entity_unique_id() -> None:
@@ -36,7 +38,9 @@ def test_connection_uid_from_entity_unique_id() -> None:
     uid = "abc"
     unique = f"{UNIQUE_ID_PREFIX}{uid}_switch"
     assert connection_uid_from_entity_unique_id(unique) == uid
-    assert connection_uid_from_entity_unique_id(f"{UNIQUE_ID_PREFIX}{uid}_status") == uid
+    assert (
+        connection_uid_from_entity_unique_id(f"{UNIQUE_ID_PREFIX}{uid}_status") == uid
+    )
     assert connection_uid_from_entity_unique_id("other") is None
 
 
@@ -249,9 +253,7 @@ async def test_remove_orphaned_entities_removes_device(hass: HomeAssistant) -> N
         identifiers={(DOMAIN, entry.entry_id, "gone")},
         name="Gone VPN",
     )
-    remove_orphaned_entities(
-        hass, entry.entry_id, [entity], remove_from_registry=True
-    )
+    remove_orphaned_entities(hass, entry.entry_id, [entity], remove_from_registry=True)
     assert entity_registry.async_get(entity.entity_id) is None
 
 
@@ -279,9 +281,7 @@ async def test_remove_orphaned_clears_known_uids(hass: HomeAssistant) -> None:
         f"{UNIQUE_ID_PREFIX}gone_switch",
         config_entry=entry,
     )
-    remove_orphaned_entities(
-        hass, entry.entry_id, [entity], remove_from_registry=False
-    )
+    remove_orphaned_entities(hass, entry.entry_id, [entity], remove_from_registry=False)
     assert entry.runtime_data.known_uids_switch == {"keep"}
 
 

--- a/tests/test_config_flow_options.py
+++ b/tests/test_config_flow_options.py
@@ -29,12 +29,15 @@ async def test_options_configure_updates_entry(
     """Options configure step updates data, options, and reloads."""
     mock_config_entry.add_to_hass(hass)
 
-    with patch(
-        "custom_components.fritzbox_vpn.flow_forms.validate_input",
-        new=AsyncMock(return_value={"title": mock_config_entry.title}),
-    ), patch.object(
-        hass.config_entries, "async_reload", new=AsyncMock()
-    ) as reload_mock:
+    with (
+        patch(
+            "custom_components.fritzbox_vpn.flow_forms.validate_input",
+            new=AsyncMock(return_value={"title": mock_config_entry.title}),
+        ),
+        patch.object(
+            hass.config_entries, "async_reload", new=AsyncMock()
+        ) as reload_mock,
+    ):
         result = await hass.config_entries.options.async_init(
             mock_config_entry.entry_id
         )
@@ -109,27 +112,27 @@ async def test_options_cleanup_confirm_removes_entities(
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     remaining = er.async_entries_for_config_entry(registry, entry.entry_id)
-    assert all(
-        "orphan" not in (e.unique_id or "")
-        for e in remaining
-    )
+    assert all("orphan" not in (e.unique_id or "") for e in remaining)
 
 
 @pytest.mark.asyncio
 async def test_user_autoconfig_from_fritz(hass: HomeAssistant) -> None:
     """User flow auto-creates entry when Fritz integration credentials work."""
-    with patch(
-        "custom_components.fritzbox_vpn.config_flow.get_existing_fritz_config",
-        new=AsyncMock(
-            return_value={
-                CONF_HOST: MOCK_HOST,
-                CONF_USERNAME: MOCK_USERNAME,
-                CONF_PASSWORD: MOCK_PASSWORD,
-            }
+    with (
+        patch(
+            "custom_components.fritzbox_vpn.config_flow.get_existing_fritz_config",
+            new=AsyncMock(
+                return_value={
+                    CONF_HOST: MOCK_HOST,
+                    CONF_USERNAME: MOCK_USERNAME,
+                    CONF_PASSWORD: MOCK_PASSWORD,
+                }
+            ),
         ),
-    ), patch(
-        "custom_components.fritzbox_vpn.flow_forms.validate_input",
-        new=AsyncMock(return_value={"title": "Fritz!Box VPN"}),
+        patch(
+            "custom_components.fritzbox_vpn.flow_forms.validate_input",
+            new=AsyncMock(return_value={"title": "Fritz!Box VPN"}),
+        ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
@@ -241,9 +244,7 @@ async def test_options_abort_when_entry_removed(
     mock_config_entry.add_to_hass(hass)
     handler = OptionsFlowHandler(mock_config_entry)
     handler.hass = hass
-    with patch.object(
-        hass.config_entries, "async_get_entry", return_value=None
-    ):
+    with patch.object(hass.config_entries, "async_get_entry", return_value=None):
         result = await handler.async_step_configure()
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "config_entry_not_found"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -32,14 +32,10 @@ def test_normalize_update_interval_clamps_and_defaults() -> None:
 
 def test_normalize_box_connections_list_and_dict() -> None:
     """boxConnections list/dict payloads normalize to uid-keyed dict."""
-    listed = normalize_box_connections(
-        [{"uid": "a", "active": 1, "name": "A"}]
-    )
+    listed = normalize_box_connections([{"uid": "a", "active": 1, "name": "A"}])
     assert listed["a"]["active"] is True
 
-    keyed = normalize_box_connections(
-        {"b": {"uid": "", "active": "true", "name": "B"}}
-    )
+    keyed = normalize_box_connections({"b": {"uid": "", "active": "true", "name": "B"}})
     assert "b" in keyed
     assert keyed["b"]["active"] is True
 
@@ -101,9 +97,7 @@ async def test_schedule_reauth_only_once(hass: HomeAssistant) -> None:
     mock_entry.state = ConfigEntryState.LOADED
 
     hass.async_create_task = MagicMock()
-    with patch.object(
-        hass.config_entries, "async_get_entry", return_value=mock_entry
-    ):
+    with patch.object(hass.config_entries, "async_get_entry", return_value=mock_entry):
         coordinator._schedule_reauth()
         coordinator._schedule_reauth()
 

--- a/tests/test_coordinator_parsing.py
+++ b/tests/test_coordinator_parsing.py
@@ -34,6 +34,8 @@ def test_resolve_update_interval() -> None:
 
 def test_pbkdf2_response_format() -> None:
     """PBKDF2 response uses expected format for valid challenge."""
-    challenge = "2$5$0123456789abcdef0123456789abcdef$5$fedcba9876543210fedcba9876543210"
+    challenge = (
+        "2$5$0123456789abcdef0123456789abcdef$5$fedcba9876543210fedcba9876543210"
+    )
     response = FritzBoxVPNSession._calculate_pbkdf2_response(challenge, "password")
     assert "$" in response

--- a/tests/test_coordinator_session.py
+++ b/tests/test_coordinator_session.py
@@ -164,7 +164,9 @@ async def test_session_toggle_off_success() -> None:
 @pytest.mark.asyncio
 async def test_session_toggle_unknown_connection() -> None:
     """Toggle returns False when connection UID is missing."""
-    http = QueuedAiohttpSession([*_login_sequence(), json_response({"data": {"init": {}}})])
+    http = QueuedAiohttpSession(
+        [*_login_sequence(), json_response({"data": {"init": {}}})]
+    )
     fb = FritzBoxVPNSession(http, MOCK_HOST, MOCK_USERNAME, MOCK_PASSWORD)
     assert await fb.async_toggle_vpn("missing", True) is False
 
@@ -206,12 +208,9 @@ async def test_session_invalidate_and_close() -> None:
 async def test_pbkdf2_login_when_supported() -> None:
     """PBKDF2 challenge format uses version=2 login."""
     challenge = (
-        "2$5$0123456789abcdef0123456789abcdef"
-        "$5$fedcba9876543210fedcba9876543210"
+        "2$5$0123456789abcdef0123456789abcdef$5$fedcba9876543210fedcba9876543210"
     )
-    pbkdf2_challenge_xml = (
-        f'<?xml version="1.0"?><SessionInfo><Challenge>{challenge}</Challenge></SessionInfo>'
-    )
+    pbkdf2_challenge_xml = f'<?xml version="1.0"?><SessionInfo><Challenge>{challenge}</Challenge></SessionInfo>'
     http = QueuedAiohttpSession(
         [
             MockAiohttpResponse(200, text=pbkdf2_challenge_xml),

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -26,7 +26,9 @@ async def test_diagnostics_redacts_credentials(
             "data": MOCK_VPN_CONNECTIONS,
         },
     )()
-    mock_config_entry.runtime_data = FritzboxVpnRuntimeData(coordinator=mock_coordinator)
+    mock_config_entry.runtime_data = FritzboxVpnRuntimeData(
+        coordinator=mock_coordinator
+    )
 
     result = await async_get_config_entry_diagnostics(hass, mock_config_entry)
 
@@ -47,7 +49,9 @@ async def test_diagnostics_skips_non_dict_connections(
         (),
         {"last_update_success": True, "data": {"bad": "value"}},
     )()
-    mock_config_entry.runtime_data = FritzboxVpnRuntimeData(coordinator=mock_coordinator)
+    mock_config_entry.runtime_data = FritzboxVpnRuntimeData(
+        coordinator=mock_coordinator
+    )
     result = await async_get_config_entry_diagnostics(hass, mock_config_entry)
     assert result["vpn_connection_count"] == 0
     assert result["vpn_connections"] == []

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -31,7 +31,9 @@ def _mock_coordinator() -> MagicMock:
 
 
 @pytest.mark.asyncio
-async def test_switch_turn_on(hass: HomeAssistant, mock_config_entry: MockConfigEntry) -> None:
+async def test_switch_turn_on(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
     """Switch turn_on calls coordinator toggle."""
     coordinator = _mock_coordinator()
     conn = MOCK_VPN_CONNECTIONS["conn-abc"]
@@ -41,11 +43,15 @@ async def test_switch_turn_on(hass: HomeAssistant, mock_config_entry: MockConfig
 
 
 @pytest.mark.asyncio
-async def test_switch_turn_on_failure(hass: HomeAssistant, mock_config_entry: MockConfigEntry) -> None:
+async def test_switch_turn_on_failure(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
     """Switch turn_on raises HomeAssistantError when toggle fails."""
     coordinator = _mock_coordinator()
     coordinator.toggle_vpn = AsyncMock(return_value=False)
-    entity = FritzBoxVPNSwitch(coordinator, mock_config_entry, "conn-abc", MOCK_VPN_CONNECTIONS["conn-abc"])
+    entity = FritzBoxVPNSwitch(
+        coordinator, mock_config_entry, "conn-abc", MOCK_VPN_CONNECTIONS["conn-abc"]
+    )
     with pytest.raises(HomeAssistantError):
         await entity.async_turn_on()
 

--- a/tests/test_entities_extended.py
+++ b/tests/test_entities_extended.py
@@ -20,7 +20,9 @@ def _coordinator(**overrides):
     coordinator = MagicMock()
     coordinator.data = overrides.get("data", MOCK_VPN_CONNECTIONS)
     coordinator.last_update_success = overrides.get("last_update_success", True)
-    coordinator.get_vpn_status = MagicMock(return_value=overrides.get("status", STATUS_CONNECTED))
+    coordinator.get_vpn_status = MagicMock(
+        return_value=overrides.get("status", STATUS_CONNECTED)
+    )
     coordinator.toggle_vpn = AsyncMock(return_value=overrides.get("toggle_ok", True))
     coordinator.async_request_refresh = AsyncMock()
     return coordinator

--- a/tests/test_fritz_config_source.py
+++ b/tests/test_fritz_config_source.py
@@ -1,6 +1,5 @@
 """Tests for Fritz config import from other integrations."""
 
-
 import pytest
 from custom_components.fritzbox_vpn.fritz_config_source import (
     _entry_has_credentials,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -77,7 +77,9 @@ async def test_unload_entry(
     mock_coordinator = AsyncMock()
     mock_coordinator.fritz_session = AsyncMock()
     mock_coordinator.fritz_session.async_close = AsyncMock()
-    mock_config_entry.runtime_data = FritzboxVpnRuntimeData(coordinator=mock_coordinator)
+    mock_config_entry.runtime_data = FritzboxVpnRuntimeData(
+        coordinator=mock_coordinator
+    )
 
     with patch.object(
         hass.config_entries,

--- a/tests/test_legacy_entity_id_repair_on_setup.py
+++ b/tests/test_legacy_entity_id_repair_on_setup.py
@@ -94,9 +94,10 @@ async def test_migrate_entry_v1_repairs_legacy_entity_ids(
     assert unique_id_to_entity_id[
         vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_VPN_UID)
     ].endswith("_vpn_uid")
-    assert unique_id_to_entity_id[
-        vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_SWITCH)
-    ] == f"switch.{slug}"
+    assert (
+        unique_id_to_entity_id[vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_SWITCH)]
+        == f"switch.{slug}"
+    )
 
 
 @pytest.mark.asyncio
@@ -121,12 +122,16 @@ async def test_migrate_entry_v2_skips_legacy_repair(hass, mock_config_entry) -> 
             entity_registry, mock_config_entry.entry_id
         )
     }
-    assert unique_id_to_entity_id[
-        vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_CONNECTED)
-    ] == f"binary_sensor.{slug}"
-    assert unique_id_to_entity_id[
-        vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_SWITCH)
-    ] == f"switch.{slug}_vpn"
+    assert (
+        unique_id_to_entity_id[
+            vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_CONNECTED)
+        ]
+        == f"binary_sensor.{slug}"
+    )
+    assert (
+        unique_id_to_entity_id[vpn_unique_id(connection_uid, UNIQUE_ID_SUFFIX_SWITCH)]
+        == f"switch.{slug}_vpn"
+    )
 
 
 @pytest.mark.asyncio
@@ -167,7 +172,9 @@ async def test_setup_does_not_rename_entities_after_device_rename(
     assert device is not None
     device_registry.async_update_device(device.id, name_by_user="Renamed VPN")
 
-    repaired = _repair_entity_ids_before_platform_setup(hass, mock_config_entry.entry_id)
+    repaired = _repair_entity_ids_before_platform_setup(
+        hass, mock_config_entry.entry_id
+    )
     assert repaired == 0
 
     assert entity_registry.async_get(connected_entity_id) is not None

--- a/tests/test_reload_no_entity_duplicates.py
+++ b/tests/test_reload_no_entity_duplicates.py
@@ -26,7 +26,9 @@ def _fake_get_vpn_status(connection_data: dict) -> str:
     active = connection_data.get("active", False)
     if not active:
         return STATUS_DISABLED
-    return STATUS_CONNECTED if connection_data.get("connected", False) else STATUS_ENABLED
+    return (
+        STATUS_CONNECTED if connection_data.get("connected", False) else STATUS_ENABLED
+    )
 
 
 def _make_fake_coordinator(hass) -> MagicMock:
@@ -46,9 +48,7 @@ def _make_fake_coordinator(hass) -> MagicMock:
     coordinator.fritz_session = MagicMock()
     coordinator.fritz_session.async_close = AsyncMock()
 
-    coordinator.async_config_entry_first_refresh = AsyncMock(
-        side_effect=lambda: None
-    )
+    coordinator.async_config_entry_first_refresh = AsyncMock(side_effect=lambda: None)
 
     return coordinator
 
@@ -127,4 +127,3 @@ async def test_reload_does_not_duplicate_entity_registry_entries(
             entity_registry, mock_config_entry.entry_id
         )
         _assert_registry_entries(entries_after_second_reload)
-

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -35,10 +35,14 @@ async def test_remove_unavailable_entities_service(
         config_entry=mock_config_entry,
     )
 
-    with patch.object(hass.config_entries, "async_reload", new=AsyncMock()) as reload_mock:
+    with patch.object(
+        hass.config_entries, "async_reload", new=AsyncMock()
+    ) as reload_mock:
         await _async_remove_unavailable_entities(
             hass,
-            type("Call", (), {"data": {"config_entry_id": mock_config_entry.entry_id}})(),
+            type(
+                "Call", (), {"data": {"config_entry_id": mock_config_entry.entry_id}}
+            )(),
         )
 
     reload_mock.assert_awaited_once()
@@ -52,10 +56,13 @@ async def test_repair_entity_id_suffixes_service(
 ) -> None:
     """Service repairs suffixed entity IDs when configured."""
     mock_config_entry.add_to_hass(hass)
-    with patch(
-        "custom_components.fritzbox_vpn.entity_registry.repair_entity_ids",
-        return_value=(0, []),
-    ), patch.object(hass.config_entries, "async_reload", new=AsyncMock()):
+    with (
+        patch(
+            "custom_components.fritzbox_vpn.entity_registry.repair_entity_ids",
+            return_value=(0, []),
+        ),
+        patch.object(hass.config_entries, "async_reload", new=AsyncMock()),
+    ):
         await _async_repair_entity_id_suffixes(
             hass,
             type("Call", (), {"data": {}})(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI an die Praktiken von [home-assistant/core](https://github.com/home-assistant/core/blob/dev/.github/workflows/ci.yaml) und [hacs/integration](https://github.com/hacs/integration/tree/main/.github/workflows) angeglichen — skaliert auf dieses HACS-Custom-Component-Repo (kein MariaDB-/Test-Sharding).

### Übernommen von HA Core / HACS

| Praxis | Umsetzung |
|--------|-----------|
| Least privilege | Workflow `permissions: {}`, Grants pro Job |
| Action-Pinning | Commit-SHAs + Versionskommentar (`checkout@v7.0.1`, `setup-python@v6.3.0`, `ruff-action`, `hacs/action`, `hassfest`, …) |
| Checkout hardening | `persist-credentials: false` |
| Runner | explizit `ubuntu-24.04` |
| Concurrency | `workflow` + PR-Nummer / Ref, `cancel-in-progress` |
| Dispatch | `lint-only`, `skip-coverage` |
| Lint | Ruff **check** + **format --check** |
| Aggregate gate | Job `CI` wertet Job-Ergebnisse aus |
| Dependency review | alle PRs, Action SHA-gepinnt (v5) |
| Actionlint | Actionlint-Version gepinnt |

### Bewusst nicht übernommen (Core-only / zu schwer)

- Test-Sharding, MariaDB/Postgres-Matrix
- pylint / mypy (dieses Repo nutzt Ruff)
- uv/prek-interne Composite Actions von Core
- Path-Filter am `on:`-Trigger (schnelle Suite; immer volle Checks auf PR/push)

### Ruleset

[`required-ci.json`](.github/rulesets/required-ci.json) um Context `CI` ergänzt. **Live-Ruleset auf GitHub ggf. manuell nachziehen** (Ruleset-ID in `.github/rulesets/README.md`).

## Test plan

- [x] `actionlint` lokal auf Workflows
- [x] `ruff check` + `ruff format --check` + `pytest` lokal
- [ ] CI auf diesem PR grün (`CI`, `Ruff`, `pytest`, `HACS validate`, `hassfest`, Actionlint)
- [ ] Nach Merge: GitHub-Ruleset um Check `CI` erweitern, falls noch nicht live

## Checklist

- [ ] Copilot Code Review abgewartet
- [x] Keine Secrets im Diff
- [x] SSDP-Helfer unverändert
- [x] Integration-`version` unverändert
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb44a-cca9-7e3d-9cf4-cff3a6b59c26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb44a-cca9-7e3d-9cf4-cff3a6b59c26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

