### PR TITLE
chore: release v1.2.4b1 beta

### DIFF
--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -16,5 +16,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.3"
+  "version": "1.2.4b1"
 }

--- a/docs/releases/v1.2.4b1.md
+++ b/docs/releases/v1.2.4b1.md
@@ -1,0 +1,15 @@
+## What's changed
+
+- **Fix (#42):** After a Fritz!Box reboot, VPN entities recover on the next poll without reloading the integration (session/SID/protocol reset on outages).
+- **Fix (#37 residual):** Setup/reload no longer destructively renames `_2` entities over an existing base entity ID (avoids recorder migration warnings).
+- **Hardening:** FritzConnection adapter uses a constructor timeout; `async_close` does not bootstrap a client during unload.
+- **Library:** Requires `fritzboxvpn==1.0.1`.
+
+### 🇩🇪 Deutsch
+
+- **Fix (#42):** Nach einem Fritz!Box-Reboot werden VPN-Entities beim nächsten Poll wieder available — ohne die Integration neu zu laden (Session/SID/Protokoll-Reset bei Ausfällen).
+- **Fix (#37 Residual):** Setup/Reload benennt `_2`-Entities nicht mehr destruktiv über eine vorhandene Basis-Entity-ID um (weniger Recorder-Warnungen).
+- **Härten:** FritzConnection-Adapter mit Constructor-Timeout; `async_close` startet beim Unload keinen Client neu.
+- **Library:** Benötigt `fritzboxvpn==1.0.1`.
+
+**Full Changelog:** https://github.com/rosch100/fritzbox-vpn/compare/v1.2.3...v1.2.4b1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Beta-Release **v1.2.4b1** mit den Fixes aus #43:

- Recovery nach Fritz!Box-Reboot ohne Reload (#42)
- Sicheres Entity-ID-Repair ohne destruktive `_2`-Renames (#37 residual)
- FritzConnection-Adapter-Härten + `fritzboxvpn==1.0.1`

## Test plan

- [ ] CI grün
- [ ] Nach Merge: Tag `v1.2.4b1` → Pre-Release
- [ ] PyPI: `fritzboxvpn==1.0.1` per workflow_dispatch publishen
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb44a-cca9-7e3d-9cf4-cff3a6b59c26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb44a-cca9-7e3d-9cf4-cff3a6b59c26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

