### PR TITLE
ci: PyPI-Publish auch für Beta-Tags wenn Version fehlt

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -24,11 +24,9 @@ permissions:
 jobs:
   publish:
     name: PyPI
-    # Best practice: Only publish when the underlying PyPI package version changes.
-    # Beta/pre-release tags (e.g. v1.2.2b1) may not bump the library version, so
-    # uploading would fail with "File already exists".
-    if: (github.event_name != 'workflow_dispatch' || github.event.inputs.confirm == 'publish')
-      && (github.event_name != 'push' || (!contains(github.ref_name, 'beta') && !contains(github.ref_name, 'b')))
+    # Publish when the library version in pyproject.toml changed (including beta
+    # tags). Skip when unchanged so re-tags do not hit "File already exists".
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.confirm == 'publish'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: pypi
@@ -45,22 +43,26 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Check whether library version changed
+      - name: Check whether library version needs publishing
         id: versioncheck
         shell: bash
         run: |
-          # Default: publish only if fritzboxvpn's library version-bump is part of the tag commit.
           publish=false
+          cur="$(python3 -c "import tomllib; print(tomllib.load(open('fritzboxvpn/pyproject.toml','rb'))['project']['version'])")"
+          echo "library_version=${cur}"
 
           # Manual publish always forces publishing.
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.confirm }}" == "publish" ]]; then
             publish=true
           else
-            # Tags point at commits; compare the tagged commit with its parent.
-            if git rev-parse HEAD^ >/dev/null 2>&1; then
-              if git diff --name-only HEAD^ HEAD | rg -q '^fritzboxvpn/pyproject\.toml$'; then
-                publish=true
-              fi
+            # Tag/push: publish when this version is not yet on PyPI (works for betas too).
+            if python3 -c "import json,sys,urllib.request; v=sys.argv[1]; d=json.load(urllib.request.urlopen('https://pypi.org/pypi/fritzboxvpn/json', timeout=30)); raise SystemExit(0 if v in d.get('releases',{}) else 1)" "$cur"
+            then
+              echo "fritzboxvpn==${cur} already on PyPI; skipping upload"
+              publish=false
+            else
+              echo "fritzboxvpn==${cur} not on PyPI; will publish"
+              publish=true
             fi
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,21 +38,27 @@ jobs:
             exit 1
           fi
 
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
         run: |
           NOTES_FILE="docs/releases/${TAG}.md"
-          ARGS=( "$TAG" --title "Release ${TAG}" )
+          TITLE="Release ${TAG}"
+          EXTRA=()
           if [[ "$TAG" == *b* || "$TAG" == *beta* ]]; then
-            ARGS+=( --prerelease )
+            EXTRA+=( --prerelease )
           fi
           if [ -f "$NOTES_FILE" ]; then
             echo "Using release notes from $NOTES_FILE"
-            ARGS+=( --notes-file "$NOTES_FILE" )
+            NOTES_ARGS=( --notes-file "$NOTES_FILE" )
           else
             echo "No release notes at $NOTES_FILE; using auto-generated notes"
-            ARGS+=( --generate-notes )
+            NOTES_ARGS=( --generate-notes )
           fi
-          gh release create "${ARGS[@]}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; updating notes/title"
+            gh release edit "$TAG" --title "$TITLE" "${EXTRA[@]}" "${NOTES_ARGS[@]}"
+          else
+            gh release create "$TAG" --title "$TITLE" "${EXTRA[@]}" "${NOTES_ARGS[@]}"
+          fi

--- a/fritzboxvpn/pyproject.toml
+++ b/fritzboxvpn/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "fritzboxvpn"
 version = "1.0.1"
-description = "Async Python library for AVM Fritz!Box WireGuard VPN Web API"
+description = "Async Python library for AVM Fritz!Box WireGuard VPN (Web UI / data.lua API)"
 readme = "README.md"
 requires-python = ">=3.11"
 license = "Apache-2.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Damit `fritzboxvpn==1.0.1` mit der Beta **v1.2.4b1** auf PyPI landet:

- Beta-Tags werden nicht mehr pauschal vom Publish ausgeschlossen
- Upload nur, wenn die Library-Version auf PyPI noch fehlt
- Release-Job ist bei Retags idempotent (`create` oder `edit`)

## Test plan

- [ ] CI grün
- [ ] Nach Merge: Tag `v1.2.4b1` neu pushen → Publish-Job lädt 1.0.1 hoch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb44a-cca9-7e3d-9cf4-cff3a6b59c26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb44a-cca9-7e3d-9cf4-cff3a6b59c26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

