### PR TITLE
fix: recover after Fritz!Box reboot connect refused (#42)

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -72,7 +72,7 @@ Du kannst das Update-Intervall (wie oft die Integration den VPN-Status prüft) i
 
 Das Update-Intervall legt fest, wie oft die Integration die FritzBox abfragt. Niedrigere Werte = häufigere Updates, höhere Werte (bis 3600 s = 1 h) reduzieren Reconnects und Last.
 
-**Reconnects und Last reduzieren:** Die Integration nutzt Session-Caching (ein Login pro Ladevorgang) und bei Abfragefehlern einen 5‑Minuten-Backoff vor dem nächsten Versuch. Für noch weniger Reconnects und FritzBox-Last das Update-Intervall auf 300 Sekunden (5 Min) oder höher setzen; Maximum ist 3600 (1 h).
+**Reconnects und Last reduzieren:** Die Integration nutzt Session-Caching (ein Login pro Ladevorgang) und bei Abfragefehlern einen 60‑Sekunden-Backoff vor dem nächsten Versuch (damit Fritz!Box-Reboots ohne manuelles Reload wieder verfügbar werden). Für noch weniger Reconnects und FritzBox-Last das Update-Intervall auf 300 Sekunden (5 Min) oder höher setzen; Maximum ist 3600 (1 h).
 
 ### Optionen und Dienste
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can configure the update interval (how often the integration checks for VPN 
 
 The update interval determines how frequently the integration polls the FritzBox for VPN status updates. Lower values give more frequent updates; higher values (e.g. 300–3600 s) reduce reconnects. You can set up to 1 hour (3600 s) for minimal load.
 
-**Reducing reconnects and load:** The integration uses session caching (one login per load) and, on fetch errors, a 5‑minute backoff before retrying. To further reduce reconnects and FritzBox load, set the update interval to 300 seconds (5 min) or higher; maximum is 3600 (1 h).
+**Reducing reconnects and load:** The integration uses session caching (one login per load) and, on fetch errors, a 60‑second backoff before retrying (so Fritz!Box reboots recover without a manual reload). To further reduce reconnects and FritzBox load, set the update interval to 300 seconds (5 min) or higher; maximum is 3600 (1 h).
 
 ### Options and services
 

--- a/custom_components/fritzbox_vpn/const.py
+++ b/custom_components/fritzbox_vpn/const.py
@@ -17,7 +17,9 @@ HOST_FALLBACK_UNKNOWN = "unknown"
 DEFAULT_UPDATE_INTERVAL = 30
 UPDATE_INTERVAL_MIN = 5
 UPDATE_INTERVAL_MAX = 3600
-RETRY_AFTER_SECONDS = 300
+# Short enough for Fritz!Box reboot recovery; long enough to avoid hammering
+# during temporary outages / login BlockTime (see issue #42).
+RETRY_AFTER_SECONDS = 60
 
 ATTR_UID = "uid"
 ATTR_VPN_UID = "vpn_uid"

--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -10,11 +10,11 @@
   "issue_tracker": "https://github.com/rosch100/fritzbox-vpn/issues",
   "loggers": ["fritzboxvpn"],
   "quality_scale": "gold",
-  "requirements": ["fritzboxvpn==1.0.1", "fritzconnection"],
+  "requirements": ["fritzboxvpn==1.0.2", "fritzconnection"],
   "ssdp": [
     {
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.4b1"
+  "version": "1.2.4b2"
 }

--- a/docs/releases/v1.2.4b2.md
+++ b/docs/releases/v1.2.4b2.md
@@ -1,0 +1,13 @@
+## What's changed
+
+- **Fix (#42):** Recover after Fritz!Box reboot when HTTPS/data.lua returns `ClientConnectorError` (connection refused): clear SID/protocol, raise a proper `ConnectionError`, and retry after 60s instead of 5 minutes.
+- **Hardening:** HTTPS→HTTP login fallback only switches protocol after a successful HTTP response (no sticky HTTP after a failed fallback).
+- **Library:** Requires `fritzboxvpn==1.0.2`.
+
+### 🇩🇪 Deutsch
+
+- **Fix (#42):** Nach Fritz!Box-Reboot mit `ClientConnectorError` (Connection refused) auf HTTPS/data.lua: SID/Protokoll zurücksetzen, sauberer `ConnectionError`, Retry nach 60 s statt 5 Minuten.
+- **Härten:** HTTPS→HTTP-Login-Fallback setzt das Protokoll erst nach erfolgreicher HTTP-Antwort (kein klebendes HTTP nach fehlgeschlagenem Fallback).
+- **Library:** Benötigt `fritzboxvpn==1.0.2`.
+
+**Full Changelog:** https://github.com/rosch100/fritzbox-vpn/compare/v1.2.4b1...v1.2.4b2

--- a/fritzboxvpn/fritzboxvpn/session.py
+++ b/fritzboxvpn/fritzboxvpn/session.py
@@ -6,7 +6,7 @@ import asyncio
 import hashlib
 import json
 import logging
-from typing import Any
+from typing import Any, NoReturn
 from urllib.parse import urlsplit
 
 from aiohttp import ClientConnectorError, ClientSession, ClientTimeout
@@ -124,12 +124,19 @@ class FritzBoxVPNSession:
             LOGIN_FORM_USERNAME: self.username,
             LOGIN_FORM_RESPONSE: f"{challenge}-{response_hash}",
         }
-        async with self.session.post(
-            login_url, data=login_data, ssl=False, timeout=timeout
-        ) as response:
-            if response.status != HTTP_STATUS_OK:
-                raise ConnectionError(f"Login failed: {response.status}")
-            content = await response.text()
+        # Rebuild after possible HTTPS→HTTP fallback in _fetch_login_page.
+        login_url = f"{self.protocol}://{self.host}{API_LOGIN}"
+        try:
+            async with self.session.post(
+                login_url, data=login_data, ssl=False, timeout=timeout
+            ) as response:
+                if response.status != HTTP_STATUS_OK:
+                    raise ConnectionError(f"Login failed: {response.status}")
+                content = await response.text()
+        except ConnectionError:
+            raise
+        except (ClientConnectorError, OSError) as err:
+            self._raise_transport_error(err)
 
         sid = parse_sid_from_login_response(content)
         if not sid or sid == INVALID_SID_VALUE:
@@ -166,18 +173,28 @@ class FritzBoxVPNSession:
         }
 
         login_url_post = f"{self.protocol}://{self.host}{API_LOGIN}?version=2"
-        async with self.session.post(
-            login_url_post, data=login_data, ssl=False, timeout=timeout
-        ) as response_http:
-            if response_http.status != HTTP_STATUS_OK:
-                return None
-            resp_content = await response_http.text()
+        try:
+            async with self.session.post(
+                login_url_post, data=login_data, ssl=False, timeout=timeout
+            ) as response_http:
+                if response_http.status != HTTP_STATUS_OK:
+                    return None
+                resp_content = await response_http.text()
+        except ConnectionError:
+            raise
+        except (ClientConnectorError, OSError) as err:
+            self._raise_transport_error(err)
 
         sid = parse_sid_from_login_response(resp_content)
         if not sid or sid == INVALID_SID_VALUE:
             return None
         _LOGGER.debug("PBKDF2 login flow succeeded for session generation.")
         return sid
+
+    def _raise_transport_error(self, err: BaseException) -> NoReturn:
+        """Clear SID/protocol and raise ConnectionError for transport failures."""
+        self.invalidate_session()
+        raise ConnectionError(f"Cannot connect to {self.host}: {err}") from err
 
     @staticmethod
     def _calculate_pbkdf2_response(challenge: str, password: str) -> str:
@@ -302,8 +319,7 @@ class FritzBoxVPNSession:
             raise
         except (ClientConnectorError, OSError) as err:
             # Reboot / port-down: clear cached SID+protocol so the next poll recovers.
-            self.invalidate_session()
-            raise ConnectionError(f"Cannot connect to {self.host}: {err}") from err
+            self._raise_transport_error(err)
 
     async def async_get_vpn_connections(self) -> dict[str, Any]:
         """WireGuard VPN connections; cached session, retry once on SID expiry."""

--- a/fritzboxvpn/fritzboxvpn/session.py
+++ b/fritzboxvpn/fritzboxvpn/session.py
@@ -83,7 +83,9 @@ class FritzBoxVPNSession:
         sid = None
         try:
             sid = await self._try_get_session_via_pbkdf2(timeout)
-        except (ConnectionError, ValueError):
+        except ValueError:
+            # Challenge/format mismatch only — transport failures must propagate
+            # so reboot outages are not masked as "try MD5 next".
             _LOGGER.debug("PBKDF2 login not usable; falling back to MD5.")
 
         if sid:
@@ -197,6 +199,29 @@ class FritzBoxVPNSession:
 
         return f"{salt2_hex}${hash2.hex()}"
 
+    async def _get_login_page_http(
+        self, api_path: str, query: str, timeout: ClientTimeout
+    ) -> str:
+        """GET login page over HTTP and switch protocol only after success."""
+        login_url = (
+            f"{PROTOCOL_HTTP}://{self.host}{api_path}{'?' + query if query else ''}"
+        )
+        try:
+            async with self.session.get(
+                login_url, ssl=False, timeout=timeout
+            ) as response:
+                if response.status != HTTP_STATUS_OK:
+                    raise ConnectionError(
+                        f"Failed to get login page: {response.status}"
+                    )
+                content = await response.text()
+        except ConnectionError:
+            raise
+        except (ClientConnectorError, OSError) as err:
+            raise ConnectionError(f"Cannot connect to {self.host}: {err}") from err
+        self.protocol = PROTOCOL_HTTP
+        return content
+
     async def _fetch_login_page(
         self, login_url: str, timeout: ClientTimeout
     ) -> str | None:
@@ -220,19 +245,7 @@ class FritzBoxVPNSession:
                         response.status,
                         NAME_FRITZBOX,
                     )
-                    self.protocol = PROTOCOL_HTTP
-                    login_url = (
-                        f"{self.protocol}://{self.host}{api_path}"
-                        f"{'?' + query if query else ''}"
-                    )
-                    async with self.session.get(
-                        login_url, ssl=False, timeout=timeout
-                    ) as retry_response:
-                        if retry_response.status != HTTP_STATUS_OK:
-                            raise ConnectionError(
-                                f"Failed to get login page: {retry_response.status}"
-                            )
-                        return await retry_response.text()
+                    return await self._get_login_page_http(api_path, query, timeout)
                 raise ConnectionError(f"Failed to get login page: {response.status}")
         except (ClientConnectorError, OSError) as err:
             if self.protocol != PROTOCOL_HTTPS:
@@ -241,18 +254,7 @@ class FritzBoxVPNSession:
                 "HTTPS connection failed (%s), falling back to HTTP.",
                 err,
             )
-            self.protocol = PROTOCOL_HTTP
-            login_url = (
-                f"{self.protocol}://{self.host}{api_path}{'?' + query if query else ''}"
-            )
-            async with self.session.get(
-                login_url, ssl=False, timeout=timeout
-            ) as response:
-                if response.status != HTTP_STATUS_OK:
-                    raise ConnectionError(
-                        f"Failed to get login page: {response.status}"
-                    ) from err
-                return await response.text()
+            return await self._get_login_page_http(api_path, query, timeout)
 
     async def _fetch_vpn_connections_once(self) -> dict[str, Any]:
         """Single VPN connections request; raises on outage/missing payload."""
@@ -266,35 +268,42 @@ class FritzBoxVPNSession:
             "no_sidrenew": "",
         }
         timeout = ClientTimeout(total=DEFAULT_TIMEOUT)
-        async with session.post(
-            data_url, data=params, timeout=timeout, ssl=False
-        ) as response:
-            if response.status == HTTP_STATUS_FORBIDDEN:
-                raise ValueError(ERROR_MSG_INVALID_SID_403)
-            if response.status != HTTP_STATUS_OK:
+        try:
+            async with session.post(
+                data_url, data=params, timeout=timeout, ssl=False
+            ) as response:
+                if response.status == HTTP_STATUS_FORBIDDEN:
+                    raise ValueError(ERROR_MSG_INVALID_SID_403)
+                if response.status != HTTP_STATUS_OK:
+                    self.invalidate_session()
+                    raise ConnectionError(
+                        f"Failed to get VPN connections: HTTP {response.status}"
+                    )
+
+                content_type = (response.headers.get("Content-Type") or "").lower()
+                if CONTENT_TYPE_JSON not in content_type:
+                    raise ValueError(ERROR_MSG_INVALID_SID_HTML)
+                try:
+                    body = await response.text()
+                    data = json.loads(body)
+                except (json.JSONDecodeError, TypeError) as err:
+                    raise ValueError(ERROR_MSG_INVALID_SID_HTML) from err
+
+                box = extract_box_connections_from_data(data, API_PAGE_SHAREWIREGUARD)
+                if box is not None:
+                    return normalize_box_connections(box)
+                # Missing boxConnections is typical while the box is rebooting or the
+                # cached SID/protocol is stale — do not soft-succeed with {}.
                 self.invalidate_session()
                 raise ConnectionError(
-                    f"Failed to get VPN connections: HTTP {response.status}"
+                    "VPN connections payload missing from Fritz!Box response"
                 )
-
-            content_type = (response.headers.get("Content-Type") or "").lower()
-            if CONTENT_TYPE_JSON not in content_type:
-                raise ValueError(ERROR_MSG_INVALID_SID_HTML)
-            try:
-                body = await response.text()
-                data = json.loads(body)
-            except (json.JSONDecodeError, TypeError) as err:
-                raise ValueError(ERROR_MSG_INVALID_SID_HTML) from err
-
-            box = extract_box_connections_from_data(data, API_PAGE_SHAREWIREGUARD)
-            if box is not None:
-                return normalize_box_connections(box)
-            # Missing boxConnections is typical while the box is rebooting or the
-            # cached SID/protocol is stale — do not soft-succeed with {}.
+        except ConnectionError:
+            raise
+        except (ClientConnectorError, OSError) as err:
+            # Reboot / port-down: clear cached SID+protocol so the next poll recovers.
             self.invalidate_session()
-            raise ConnectionError(
-                "VPN connections payload missing from Fritz!Box response"
-            )
+            raise ConnectionError(f"Cannot connect to {self.host}: {err}") from err
 
     async def async_get_vpn_connections(self) -> dict[str, Any]:
         """WireGuard VPN connections; cached session, retry once on SID expiry."""
@@ -307,6 +316,9 @@ class FritzBoxVPNSession:
             raise
         except TimeoutError as err:
             _LOGGER.error("Timeout getting VPN connections: %s", err)
+            raise
+        except ConnectionError as err:
+            _LOGGER.error("Error getting VPN connections: %s", err)
             raise
         except Exception as err:
             _LOGGER.error("Error getting VPN connections: %s", err)

--- a/fritzboxvpn/pyproject.toml
+++ b/fritzboxvpn/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fritzboxvpn"
-version = "1.0.1"
+version = "1.0.2"
 description = "Async Python library for AVM Fritz!Box WireGuard VPN (Web UI / data.lua API)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/aiohttp_mock.py
+++ b/tests/aiohttp_mock.py
@@ -34,16 +34,19 @@ class MockAiohttpResponse:
 class QueuedAiohttpSession:
     """ClientSession that returns queued responses in order for get/post/put."""
 
-    def __init__(self, responses: list[MockAiohttpResponse]) -> None:
-        self._responses: Iterator[MockAiohttpResponse] = iter(responses)
+    def __init__(self, responses: list[MockAiohttpResponse | BaseException]) -> None:
+        self._responses: Iterator[MockAiohttpResponse | BaseException] = iter(responses)
         self.requests: list[tuple[str, str, dict[str, Any]]] = []
 
     def _dequeue(self, method: str, url: str, **kwargs: Any) -> MockAiohttpResponse:
         self.requests.append((method, url, kwargs))
         try:
-            return next(self._responses)
+            item = next(self._responses)
         except StopIteration as err:
             raise AssertionError(f"No mock response left for {method} {url}") from err
+        if isinstance(item, BaseException):
+            raise item
+        return item
 
     def get(self, url: str, **kwargs: Any) -> MockAiohttpResponse:
         return self._dequeue("GET", url, **kwargs)

--- a/tests/test_session_reboot_recovery.py
+++ b/tests/test_session_reboot_recovery.py
@@ -228,3 +228,67 @@ async def test_coordinator_client_connector_error_uses_short_retry(
     assert exc_info.value.retry_after == RETRY_AFTER_SECONDS
     assert RETRY_AFTER_SECONDS <= 60
     coordinator.fritz_session.invalidate_session.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_md5_login_post_uses_http_after_https_get_fallback() -> None:
+    """After HTTPS GET fails and HTTP login-page succeeds, MD5 POST must use HTTP."""
+    http = QueuedAiohttpSession(
+        [
+            # PBKDF2 probe: HTTPS OK with legacy challenge → fall through to MD5
+            MockAiohttpResponse(200, text=LOGIN_XML_CHALLENGE),
+            # MD5 GET: HTTPS refused → HTTP challenge OK → MD5 POST on HTTP
+            _connector_error(port=443),
+            MockAiohttpResponse(200, text=LOGIN_XML_CHALLENGE),
+            MockAiohttpResponse(200, text=LOGIN_XML_SID),
+        ]
+    )
+    fb = FritzBoxVPNSession(http, MOCK_HOST, MOCK_USERNAME, MOCK_PASSWORD)
+    session, sid = await fb.async_get_session()
+    assert session is http
+    assert sid == "deadbeef"
+    assert fb.protocol == "http"
+    post_urls = [url for method, url, _ in http.requests if method == "POST"]
+    assert post_urls
+    assert all(url.startswith("http://") for url in post_urls)
+    assert not any(url.startswith("https://") for url in post_urls)
+
+
+@pytest.mark.asyncio
+async def test_md5_login_post_connector_error_raises_connection_error() -> None:
+    """MD5 auth POST connect refused maps to ConnectionError and clears session."""
+    http = QueuedAiohttpSession(
+        [
+            MockAiohttpResponse(200, text=LOGIN_XML_CHALLENGE),
+            MockAiohttpResponse(200, text=LOGIN_XML_CHALLENGE),
+            _connector_error(port=443),
+        ]
+    )
+    fb = FritzBoxVPNSession(http, MOCK_HOST, MOCK_USERNAME, MOCK_PASSWORD)
+    with pytest.raises(ConnectionError, match="Cannot connect"):
+        await fb.async_get_session()
+    assert fb.sid is None
+    assert fb.protocol == "https"
+
+
+@pytest.mark.asyncio
+async def test_pbkdf2_login_post_connector_error_raises_connection_error() -> None:
+    """PBKDF2 version=2 auth POST connect refused maps to ConnectionError."""
+    challenge = (
+        "2$5$0123456789abcdef0123456789abcdef$5$fedcba9876543210fedcba9876543210"
+    )
+    pbkdf2_challenge_xml = (
+        f'<?xml version="1.0"?><SessionInfo><Challenge>{challenge}</Challenge>'
+        f"</SessionInfo>"
+    )
+    http = QueuedAiohttpSession(
+        [
+            MockAiohttpResponse(200, text=pbkdf2_challenge_xml),
+            _connector_error(port=443),
+        ]
+    )
+    fb = FritzBoxVPNSession(http, MOCK_HOST, MOCK_USERNAME, MOCK_PASSWORD)
+    with pytest.raises(ConnectionError, match="Cannot connect"):
+        await fb.async_get_session()
+    assert fb.sid is None
+    assert fb.protocol == "https"

--- a/tests/test_session_reboot_recovery.py
+++ b/tests/test_session_reboot_recovery.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from aiohttp import ClientConnectorError
+from custom_components.fritzbox_vpn.const import RETRY_AFTER_SECONDS
 from custom_components.fritzbox_vpn.coordinator import FritzBoxVPNCoordinator
 from fritzboxvpn import FritzBoxVPNSession
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -18,6 +20,17 @@ from tests.fixtures import (
     MOCK_PASSWORD,
     MOCK_USERNAME,
 )
+
+
+def _connector_error(host: str = MOCK_HOST, port: int = 443) -> ClientConnectorError:
+    """Build an aiohttp ClientConnectorError like a refused Fritz!Box port."""
+    conn_key = MagicMock()
+    conn_key.host = host
+    conn_key.port = port
+    conn_key.ssl = False
+    return ClientConnectorError(
+        conn_key, OSError(111, f"Connect call failed ('{host}', {port})")
+    )
 
 
 def _login_sequence() -> list[MockAiohttpResponse]:
@@ -137,3 +150,81 @@ async def test_missing_box_connections_invalidates_and_raises() -> None:
     with pytest.raises(ConnectionError, match="payload missing"):
         await fb.async_get_vpn_connections()
     assert fb.sid is None
+
+
+@pytest.mark.asyncio
+async def test_connect_refused_on_data_lua_invalidates_and_raises_connection_error() -> (
+    None
+):
+    """Reboot ConnectionRefused on data.lua must clear SID and raise ConnectionError.
+
+    Reporter log (#42): ClientConnectorError during session.post must not leave a
+    cached SID and must not surface as an unhandled aiohttp exception.
+    """
+    http = QueuedAiohttpSession(
+        [
+            *_login_sequence(),
+            _connector_error(),
+        ]
+    )
+    fb = FritzBoxVPNSession(http, MOCK_HOST, MOCK_USERNAME, MOCK_PASSWORD)
+    with pytest.raises(ConnectionError, match="Cannot connect"):
+        await fb.async_get_vpn_connections()
+    assert fb.sid is None
+    assert fb.protocol == "https"
+
+
+@pytest.mark.asyncio
+async def test_connect_refused_then_recovers_on_next_poll() -> None:
+    """After connect-refused outage, the next poll re-logins and returns data."""
+    http = QueuedAiohttpSession(
+        [
+            *_login_sequence(),
+            _connector_error(),
+            *_login_sequence(),
+            json_response(MOCK_DATA_LUA_JSON),
+        ]
+    )
+    fb = FritzBoxVPNSession(http, MOCK_HOST, MOCK_USERNAME, MOCK_PASSWORD)
+    with pytest.raises(ConnectionError):
+        await fb.async_get_vpn_connections()
+    connections = await fb.async_get_vpn_connections()
+    assert "conn-abc" in connections
+
+
+@pytest.mark.asyncio
+async def test_https_and_http_connect_refused_does_not_stick_protocol_to_http() -> None:
+    """Failed HTTPS→HTTP fallback must not leave protocol permanently on HTTP."""
+    http = QueuedAiohttpSession(
+        [
+            _connector_error(port=443),  # HTTPS login
+            _connector_error(port=80),  # HTTP fallback
+        ]
+    )
+    fb = FritzBoxVPNSession(http, MOCK_HOST, MOCK_USERNAME, MOCK_PASSWORD)
+    with pytest.raises(ConnectionError, match="Cannot connect"):
+        await fb.async_get_session()
+    assert fb.protocol == "https"
+    assert fb.sid is None
+
+
+@pytest.mark.asyncio
+async def test_coordinator_client_connector_error_uses_short_retry(
+    hass,
+) -> None:
+    """Transport failures use UpdateFailed.retry_after suited for reboot recovery."""
+    coordinator = FritzBoxVPNCoordinator(
+        hass,
+        {"host": MOCK_HOST, "username": "u", "password": "p"},
+        None,
+        "entry-1",
+    )
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        side_effect=ConnectionError("Cannot connect to host")
+    )
+    coordinator.fritz_session.invalidate_session = MagicMock()
+    with pytest.raises(UpdateFailed) as exc_info:
+        await coordinator._async_update_data()
+    assert exc_info.value.retry_after == RETRY_AFTER_SECONDS
+    assert RETRY_AFTER_SECONDS <= 60
+    coordinator.fritz_session.invalidate_session.assert_called_once()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up for **#42** after `v1.2.4b1`: reporter confirmed entity-ID migration warnings are gone, but entities still stayed unavailable after a Fritz!Box reboot (connection refused on `:443` during outage; recovery only after manual reload).

### Root cause
1. `aiohttp.ClientConnectorError` on `data.lua` (cached SID) was re-raised raw — not converted to `ConnectionError` / SID not cleared in the library.
2. HTTPS→HTTP login fallback set `protocol=http` *before* the HTTP attempt succeeded, so a failed fallback left sticky HTTP.
3. PBKDF2 path swallowed `ConnectionError` and fell through to MD5 (masking outages).
4. Coordinator `retry_after` was **300s**, so recovery was delayed well beyond a typical reboot window.

### Fix
- Library (`fritzboxvpn` **1.0.2**): wrap connect errors, invalidate session, only flip to HTTP after success.
- Integration **1.2.4b2**: `RETRY_AFTER_SECONDS` **60**.

### CodeRabbit follow-up
- MD5 auth POST rebuilds URL from `self.protocol` after HTTPS→HTTP login-page fallback.
- MD5 and PBKDF2 login POSTs map `ClientConnectorError`/`OSError` like `data.lua` (shared `_raise_transport_error`).
- Regression tests for HTTP MD5 POST after fallback and connector failures on both login POSTs.

## Test plan
- [x] `pytest tests/` — 184 passed, coverage ≥85%
- [x] New regression tests for connect-refused, sticky-HTTP, short retry_after, MD5 HTTP POST, login POST transport errors
- [ ] After merge: publish `fritzboxvpn==1.0.2`, tag `v1.2.4b2`, ask @erkr to retest reboot without reload

## Issues
- Fixes residual of #42 (entities unavailable after FB reboot)
- #37 residual (recorder migrate warnings) already confirmed fixed in b1 — no change needed there

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb44a-cca9-7e3d-9cf4-cff3a6b59c26?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb44a-cca9-7e3d-9cf4-cff3a6b59c26&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery after Fritz!Box reboots and temporary connection failures.
  * Failed connections now clear stale sessions and retry cleanly without incorrectly forcing HTTP mode.
  * Retry intervals after fetch errors are reduced to 60 seconds for faster recovery.

* **Documentation**
  * Updated English and German documentation to reflect the 60-second retry interval.
  * Added release notes covering reboot recovery and connection handling improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->