### PR TITLE
docs: always create PRs with draft=false

### DIFF
--- a/.cursor/rules/pr-ready-for-review.mdc
+++ b/.cursor/rules/pr-ready-for-review.mdc
@@ -1,0 +1,12 @@
+---
+description: Always open GitHub PRs as ready for review (never draft)
+alwaysApply: true
+---
+
+# Pull requests: never draft
+
+When creating or updating a GitHub pull request in this repository:
+
+- **Always** set `draft=false` (`ManagePullRequest` / `gh pr create --draft=false`).
+- Do **not** open PRs as Draft. Do not rely on a manual “Ready for review” click.
+- If a PR was accidentally created as draft, convert it immediately (`gh pr ready`).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,7 +39,7 @@ Prefer suggestions over nits for line length in legacy files (Ruff ignores `E501
 
 ## Pull requests
 
-Open PRs as **ready for review** (not draft). Agents must use `draft=false` so Copilot/CodeRabbit run without a manual “Ready for review” click.
+**Always `draft=false`.** Never open PRs as draft. Pass `draft=false` explicitly to `ManagePullRequest` / do not use `gh pr create --draft`. If a PR is draft by mistake, run `gh pr ready` immediately.
 
 ## CI expectations
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,6 +37,10 @@ Flag as blocking when you see:
 
 Prefer suggestions over nits for line length in legacy files (Ruff ignores `E501`).
 
+## Pull requests
+
+Open PRs as **ready for review** (not draft). Agents must use `draft=false` so Copilot/CodeRabbit run without a manual “Ready for review” click.
+
 ## CI expectations
 
 PRs should pass the **CI** workflow jobs: `CI` (aggregate), `Ruff`, `pytest`, `HACS validate`, `hassfest`.

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -2,7 +2,9 @@
 
 ## Copilot code review (aktiv)
 
-`copilot-code-review.json` – automatische Copilot-Reviews auf PRs (alle Branches, bei jedem Push).
+`copilot-code-review.json` – automatische Copilot-Reviews auf PRs (alle Branches, bei jedem Push), inkl. Draft-PRs (`review_draft_pull_requests: true`).
+
+PRs sollen beim Anlegen bereits **bereit zur Überprüfung** sein (nicht als Draft); siehe `AGENTS.md`.
 
 ## Required CI checks (aktiv)
 

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -4,7 +4,7 @@
 
 `copilot-code-review.json` – automatische Copilot-Reviews auf PRs (alle Branches, bei jedem Push), inkl. Draft-PRs (`review_draft_pull_requests: true`).
 
-PRs sollen beim Anlegen bereits **bereit zur Überprüfung** sein (nicht als Draft); siehe `AGENTS.md`.
+PRs **immer** mit `draft=false` anlegen (nie als Draft); siehe `AGENTS.md` und `.cursor/rules/pr-ready-for-review.mdc`.
 
 ## Required CI checks (aktiv)
 

--- a/.github/rulesets/copilot-code-review.json
+++ b/.github/rulesets/copilot-code-review.json
@@ -13,7 +13,7 @@
       "type": "copilot_code_review",
       "parameters": {
         "review_on_push": true,
-        "review_draft_pull_requests": false
+        "review_draft_pull_requests": true
       }
     }
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,13 @@ Vor Merge: CI-Jobs `Ruff`, `pytest`, `HACS validate`, `hassfest` (Aggregate-Chec
 
 ## Pull Requests
 
-PRs **direkt als bereit zur Überprüfung** anlegen (nicht als Draft).  
-`gh pr create` / `ManagePullRequest` mit `draft=false` — kein manuelles „Ready for review“.
+**Immer `draft=false`.** PRs nie als Draft anlegen.
+
+- `ManagePullRequest`: `draft=false` (nicht weglassen — Default vieler Agents ist Draft)
+- `gh pr create` ohne `--draft`
+- Falls versehentlich Draft: sofort `gh pr ready`
+
+Kein manuelles „Ready for review“.
 
 ## Core-Vorbereitung
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,11 @@ python3 -m venv .venv
 
 Vor Merge: CI-Jobs `Ruff`, `pytest`, `HACS validate`, `hassfest` (Aggregate-Check `CI`).
 
+## Pull Requests
+
+PRs **direkt als bereit zur Überprüfung** anlegen (nicht als Draft).  
+`gh pr create` / `ManagePullRequest` mit `draft=false` — kein manuelles „Ready for review“.
+
 ## Core-Vorbereitung
 
 API-Library `fritzboxvpn/` (PyPI vor Core-Merge), Core-Pfad unter `home-assistant-core/homeassistant/components/fritzbox_vpn/`. Details: `docs/pypi-publish.md`, `docs/home-assistant-io/fritzbox_vpn.markdown`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PRs in this repo must **always** be opened ready for review (`draft=false`), never as Draft.

### Changes
- `AGENTS.md` / `.github/copilot-instructions.md`: mandatory `draft=false`
- `.cursor/rules/pr-ready-for-review.mdc`: `alwaysApply: true` for Cursor agents
- Ruleset JSON documents draft reviews as fallback (live GitHub ruleset still needs the checkbox if you want Copilot on drafts)

This PR itself is non-draft.

## Test plan
- [x] PR #48 has `"isDraft": false`
- [ ] Merge so future agent runs pick up the rule from `main`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb44a-cca9-7e3d-9cf4-cff3a6b59c26?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb44a-cca9-7e3d-9cf4-cff3a6b59c26&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

