### PR TITLE
fix: Entity-Lifecycle nach Reboot — kein _2/unique_id-Churn (#37)

### DIFF
--- a/custom_components/fritzbox_vpn/__init__.py
+++ b/custom_components/fritzbox_vpn/__init__.py
@@ -229,7 +229,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: FritzboxVpnConfigEntry) 
             removed_shadow_entities = remove_unexpected_entity_entries(
                 hass,
                 entry.entry_id,
-                current_uids=set(coordinator.data.keys()),
             )
             if removed_shadow_entities:
                 _LOGGER.info(

--- a/custom_components/fritzbox_vpn/__init__.py
+++ b/custom_components/fritzbox_vpn/__init__.py
@@ -102,22 +102,6 @@ async def _async_repair_entity_id_suffixes(
             )
 
 
-def _apply_auto_cleanup(
-    hass: HomeAssistant, entry_id: str, current_uids: set[str]
-) -> None:
-    """Clear known_uids for UIDs no longer present; do not remove from registry so entity_id stays stable."""
-    to_remove, err = get_orphaned_entity_entries(
-        hass, entry_id, current_uids=current_uids
-    )
-    if err or not to_remove:
-        return
-    remove_orphaned_entities(hass, entry_id, to_remove, remove_from_registry=False)
-    _LOGGER.info(
-        "Cleared known_uids for %d unavailable connection(s); entity IDs kept",
-        len(to_remove),
-    )
-
-
 def _register_services_if_needed(hass: HomeAssistant) -> None:
     """Register integration services once per HA instance."""
     store = _domain_store(hass)
@@ -215,7 +199,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: FritzboxVpnConfigEntry) 
         entry.data,
         entry.options,
         entry.entry_id,
-        on_orphaned_removed=lambda eid, cu: _apply_auto_cleanup(hass, eid, cu),
     )
 
     try:

--- a/custom_components/fritzbox_vpn/const.py
+++ b/custom_components/fritzbox_vpn/const.py
@@ -20,6 +20,9 @@ UPDATE_INTERVAL_MAX = 3600
 # Short enough for Fritz!Box reboot recovery; long enough to avoid hammering
 # during temporary outages / login BlockTime (see issue #42).
 RETRY_AFTER_SECONDS = 60
+# Consecutive successful polls a UID must be missing before we treat it as removed
+# (avoids reboot/partial-list noise; see issue #37 residual).
+ORPHAN_CONFIRM_POLLS = 3
 
 ATTR_UID = "uid"
 ATTR_VPN_UID = "vpn_uid"

--- a/custom_components/fritzbox_vpn/coordinator.py
+++ b/custom_components/fritzbox_vpn/coordinator.py
@@ -161,9 +161,15 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
     def _remember_connection_names(self, connections: dict[str, Any]) -> None:
         """Cache display names so orphan warnings stay useful after partial polls."""
         for uid, payload in connections.items():
+            if not isinstance(payload, dict):
+                continue
             name = payload.get(API_KEY_NAME)
             if name:
-                self._uid_names[uid] = name
+                self._uid_names[uid] = str(name)
+
+    def _reset_orphan_miss_streaks(self) -> None:
+        """Clear in-progress miss counts so confirmations require consecutive successes."""
+        self._missing_uid_counts.clear()
 
     def _track_missing_uids(self, current_uids: set[str]) -> set[str]:
         """Return UIDs newly confirmed missing after ORPHAN_CONFIRM_POLLS polls."""
@@ -204,6 +210,7 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
             self._reauth_scheduled = False
             return connections
         except (ConnectionError, ValueError) as err:
+            self._reset_orphan_miss_streaks()
             self._prepare_session_for_retry(err)
             if self._is_auth_error(err):
                 self._schedule_reauth()
@@ -213,12 +220,14 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
                 retry_after=RETRY_AFTER_SECONDS,
             ) from err
         except TimeoutError as err:
+            self._reset_orphan_miss_streaks()
             self._prepare_session_for_retry(err)
             raise UpdateFailed(
                 f"Error fetching VPN data: {err}",
                 retry_after=RETRY_AFTER_SECONDS,
             ) from err
         except Exception as err:
+            self._reset_orphan_miss_streaks()
             self._prepare_session_for_retry(err)
             if self._is_auth_error(err):
                 self._schedule_reauth()

--- a/custom_components/fritzbox_vpn/coordinator.py
+++ b/custom_components/fritzbox_vpn/coordinator.py
@@ -24,6 +24,7 @@ from .const import (
     LOG_MSG_VPN_CONNECTIONS_REMOVED,
     LOG_MSG_VPN_CONNECTIONS_REMOVED_HINT,
     NAME_FRITZBOX,
+    ORPHAN_CONFIRM_POLLS,
     RETRY_AFTER_SECONDS,
     STATUS_CONNECTED,
     STATUS_DISABLED,
@@ -112,6 +113,9 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
         self.entry_id = entry_id
         self._reauth_scheduled = False
         self._on_orphaned_removed = on_orphaned_removed
+        self._seen_uids: set[str] = set()
+        self._missing_uid_counts: dict[str, int] = {}
+        self._confirmed_orphan_uids: set[str] = set()
 
     def get_vpn_status(self, connection_uid: str) -> str:
         """Get the textual status of a VPN connection."""
@@ -153,27 +157,44 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
         if inspect.isawaitable(result):
             await result
 
+    def _track_missing_uids(self, current_uids: set[str]) -> set[str]:
+        """Return UIDs newly confirmed missing after ORPHAN_CONFIRM_POLLS polls."""
+        if self.data:
+            self._seen_uids |= set(self.data.keys())
+        self._seen_uids |= current_uids
+        for uid in current_uids:
+            self._missing_uid_counts.pop(uid, None)
+            self._confirmed_orphan_uids.discard(uid)
+
+        newly_confirmed: set[str] = set()
+        for uid in self._seen_uids - current_uids:
+            count = self._missing_uid_counts.get(uid, 0) + 1
+            self._missing_uid_counts[uid] = count
+            if count >= ORPHAN_CONFIRM_POLLS and uid not in self._confirmed_orphan_uids:
+                self._confirmed_orphan_uids.add(uid)
+                newly_confirmed.add(uid)
+        return newly_confirmed
+
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch latest VPN data from Fritz!Box."""
-        previous_uids = set(self.data.keys()) if self.data else set()
+        previous_data = self.data if self.data else {}
         try:
             connections = await self.fritz_session.async_get_vpn_connections()
-            if previous_uids:
-                current_uids = set(connections.keys())
-                removed_uids = previous_uids - current_uids
-                if removed_uids:
-                    names = [
-                        self.data.get(uid, {}).get(API_KEY_NAME, uid)
-                        for uid in removed_uids
-                    ]
-                    _LOGGER.warning(
-                        LOG_MSG_VPN_CONNECTIONS_REMOVED,
-                        NAME_FRITZBOX,
-                        names or list(removed_uids),
-                    )
-                    _LOGGER.info(LOG_MSG_VPN_CONNECTIONS_REMOVED_HINT)
-                    if self._on_orphaned_removed and self.entry_id:
-                        self._on_orphaned_removed(self.entry_id, current_uids)
+            current_uids = set(connections.keys())
+            newly_confirmed = self._track_missing_uids(current_uids)
+            if newly_confirmed:
+                names = [
+                    previous_data.get(uid, {}).get(API_KEY_NAME, uid)
+                    for uid in newly_confirmed
+                ]
+                _LOGGER.warning(
+                    LOG_MSG_VPN_CONNECTIONS_REMOVED,
+                    NAME_FRITZBOX,
+                    names or list(newly_confirmed),
+                )
+                _LOGGER.info(LOG_MSG_VPN_CONNECTIONS_REMOVED_HINT)
+                if self._on_orphaned_removed and self.entry_id:
+                    self._on_orphaned_removed(self.entry_id, current_uids)
             self._reauth_scheduled = False
             return connections
         except (ConnectionError, ValueError) as err:

--- a/custom_components/fritzbox_vpn/coordinator.py
+++ b/custom_components/fritzbox_vpn/coordinator.py
@@ -116,6 +116,7 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
         self._seen_uids: set[str] = set()
         self._missing_uid_counts: dict[str, int] = {}
         self._confirmed_orphan_uids: set[str] = set()
+        self._uid_names: dict[str, str] = {}
 
     def get_vpn_status(self, connection_uid: str) -> str:
         """Get the textual status of a VPN connection."""
@@ -157,10 +158,18 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
         if inspect.isawaitable(result):
             await result
 
+    def _remember_connection_names(self, connections: dict[str, Any]) -> None:
+        """Cache display names so orphan warnings stay useful after partial polls."""
+        for uid, payload in connections.items():
+            name = payload.get(API_KEY_NAME)
+            if name:
+                self._uid_names[uid] = name
+
     def _track_missing_uids(self, current_uids: set[str]) -> set[str]:
         """Return UIDs newly confirmed missing after ORPHAN_CONFIRM_POLLS polls."""
         if self.data:
             self._seen_uids |= set(self.data.keys())
+            self._remember_connection_names(self.data)
         self._seen_uids |= current_uids
         for uid in current_uids:
             self._missing_uid_counts.pop(uid, None)
@@ -177,16 +186,13 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch latest VPN data from Fritz!Box."""
-        previous_data = self.data if self.data else {}
         try:
             connections = await self.fritz_session.async_get_vpn_connections()
             current_uids = set(connections.keys())
+            self._remember_connection_names(connections)
             newly_confirmed = self._track_missing_uids(current_uids)
             if newly_confirmed:
-                names = [
-                    previous_data.get(uid, {}).get(API_KEY_NAME, uid)
-                    for uid in newly_confirmed
-                ]
+                names = [self._uid_names.get(uid, uid) for uid in newly_confirmed]
                 _LOGGER.warning(
                     LOG_MSG_VPN_CONNECTIONS_REMOVED,
                     NAME_FRITZBOX,

--- a/custom_components/fritzbox_vpn/entity.py
+++ b/custom_components/fritzbox_vpn/entity.py
@@ -8,7 +8,6 @@ from typing import Any
 
 from fritzboxvpn import API_KEY_ACTIVE, API_KEY_CONNECTED, API_KEY_NAME, API_KEY_UID
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -24,7 +23,6 @@ from .const import (
     UNIQUE_ID_PREFIX,
 )
 from .coordinator import FritzBoxVPNCoordinator
-from .entity_registry import connection_uid_from_entity_unique_id
 from .models import FritzboxVpnConfigEntry, RuntimePlatform, runtime_from_entry
 
 _LOGGER = logging.getLogger(__name__)
@@ -229,35 +227,21 @@ async def setup_vpn_platform(
 
     async_add_entities(entities, update_before_add=True)
 
-    def _uids_already_in_registry(uids: set[str]) -> set[str]:
-        """UIDs that already have registry rows for this config entry."""
-        if not uids:
-            return set()
-        registry = er.async_get(coordinator.hass)
-        present: set[str] = set()
-        for reg_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
-            uid = connection_uid_from_entity_unique_id(reg_entry.unique_id or "")
-            if uid in uids:
-                present.add(uid)
-        return present
-
     async def _add_new_entities() -> None:
         async with lock:
             current = set(coordinator.data.keys()) if coordinator.data else set()
             new_uids = current - known_uids
             if not new_uids:
                 return
-            # Defense-in-depth: never re-add unique_ids that still exist in the
-            # registry (e.g. after a buggy known_uids clear during reboot).
-            already_registered = _uids_already_in_registry(new_uids)
-            known_uids.update(already_registered)
-            to_add = new_uids - already_registered
-            if not to_add:
-                return
-            new_entities = create_entities(coordinator, to_add)
+            # Add for UIDs not yet tracked in this loaded session. Registry rows
+            # alone must not block this: after setup with a partial poll (reboot),
+            # missing connections still need async_add_entities so HA can restore
+            # the existing unique_id / entity_id. Duplicate live unique_ids are
+            # avoided by never clearing known_uids on temporary absence.
+            new_entities = create_entities(coordinator, new_uids)
             if not new_entities:
                 return
-            known_uids.update(to_add)
+            known_uids.update(new_uids)
             async_add_entities(new_entities)
             _LOGGER.info(
                 "New VPN connection(s) detected, added %d %s entities",

--- a/custom_components/fritzbox_vpn/entity.py
+++ b/custom_components/fritzbox_vpn/entity.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from fritzboxvpn import API_KEY_ACTIVE, API_KEY_CONNECTED, API_KEY_NAME, API_KEY_UID
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -23,6 +24,7 @@ from .const import (
     UNIQUE_ID_PREFIX,
 )
 from .coordinator import FritzBoxVPNCoordinator
+from .entity_registry import connection_uid_from_entity_unique_id
 from .models import FritzboxVpnConfigEntry, RuntimePlatform, runtime_from_entry
 
 _LOGGER = logging.getLogger(__name__)
@@ -227,16 +229,35 @@ async def setup_vpn_platform(
 
     async_add_entities(entities, update_before_add=True)
 
+    def _uids_already_in_registry(uids: set[str]) -> set[str]:
+        """UIDs that already have registry rows for this config entry."""
+        if not uids:
+            return set()
+        registry = er.async_get(coordinator.hass)
+        present: set[str] = set()
+        for reg_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
+            uid = connection_uid_from_entity_unique_id(reg_entry.unique_id or "")
+            if uid in uids:
+                present.add(uid)
+        return present
+
     async def _add_new_entities() -> None:
         async with lock:
             current = set(coordinator.data.keys()) if coordinator.data else set()
             new_uids = current - known_uids
             if not new_uids:
                 return
-            new_entities = create_entities(coordinator, new_uids)
+            # Defense-in-depth: never re-add unique_ids that still exist in the
+            # registry (e.g. after a buggy known_uids clear during reboot).
+            already_registered = _uids_already_in_registry(new_uids)
+            known_uids.update(already_registered)
+            to_add = new_uids - already_registered
+            if not to_add:
+                return
+            new_entities = create_entities(coordinator, to_add)
             if not new_entities:
                 return
-            known_uids.update(new_uids)
+            known_uids.update(to_add)
             async_add_entities(new_entities)
             _LOGGER.info(
                 "New VPN connection(s) detected, added %d %s entities",

--- a/custom_components/fritzbox_vpn/entity.py
+++ b/custom_components/fritzbox_vpn/entity.py
@@ -241,7 +241,19 @@ async def setup_vpn_platform(
             new_entities = create_entities(coordinator, new_uids)
             if not new_entities:
                 return
-            known_uids.update(new_uids)
+            # Only mark UIDs that were actually built (factory skips absent data).
+            added_uids: set[str] = set()
+            for entity in new_entities:
+                uid = getattr(entity, "_connection_uid", None)
+                if isinstance(uid, str):
+                    added_uids.add(uid)
+            if not added_uids:
+                added_uids = new_uids & (
+                    set(coordinator.data.keys()) if coordinator.data else set()
+                )
+            if not added_uids:
+                return
+            known_uids.update(added_uids)
             async_add_entities(new_entities)
             _LOGGER.info(
                 "New VPN connection(s) detected, added %d %s entities",

--- a/custom_components/fritzbox_vpn/entity_registry.py
+++ b/custom_components/fritzbox_vpn/entity_registry.py
@@ -109,18 +109,17 @@ def remove_unexpected_entity_entries(
     *,
     current_uids: set[str],
 ) -> int:
-    """Remove entity registry entries that are not provided anymore.
+    """Remove shadow entities with broken unique_id formats.
 
-    This primarily fixes "shadow" entities caused by wrong/broken unique_id
-    generation across upgrades: if an entry's unique_id does not match any of
-    our expected unique_id values for the currently known VPN connections,
-    remove it from the entity registry.
+    Only removes registry entries whose unique_id starts with our prefix but is
+    not a valid ``fritzbox_vpn_{uid}_{suffix}`` value. Valid-format entities for
+    UIDs missing from the current poll are kept (temporary reboot / partial
+    lists must not destroy registry rows; see issue #37 residual).
+
+    ``current_uids`` is accepted for API compatibility with setup callers; it is
+    not used to delete valid entries.
     """
-    expected_unique_ids = {
-        f"{UNIQUE_ID_PREFIX}{uid}_{suffix}"
-        for uid in current_uids
-        for suffix in UNIQUE_ID_SUFFIXES
-    }
+    _ = current_uids  # API compat; do not delete based on transient poll sets.
 
     entity_registry = er.async_get(hass)
     to_remove: list[er.RegistryEntry] = []
@@ -128,7 +127,7 @@ def remove_unexpected_entity_entries(
         unique_id = entry.unique_id or ""
         if not unique_id.startswith(UNIQUE_ID_PREFIX):
             continue
-        if unique_id in expected_unique_ids:
+        if connection_uid_from_entity_unique_id(unique_id) is not None:
             continue
         to_remove.append(entry)
 
@@ -320,50 +319,54 @@ def remove_orphaned_entities(
     *,
     remove_from_registry: bool = True,
 ) -> None:
-    """Clear known_uids and optionally remove entity/device registry entries."""
+    """Optionally remove registry entries; clear known_uids only when removed."""
     if not entries:
         return
 
     uids_removed = uids_from_entity_entries(entries)
 
-    if remove_from_registry:
-        entity_registry = er.async_get(hass)
-        device_ids_affected = set()
-        for entry in entries:
-            if entry.device_id:
-                device_ids_affected.add(entry.device_id)
-            entity_registry.async_remove(entry.entity_id)
+    if not remove_from_registry:
+        # Keep known_uids so platforms do not re-add existing unique_ids when a
+        # connection reappears after a temporary absence (issue #37 residual).
+        return
+
+    entity_registry = er.async_get(hass)
+    device_ids_affected = set()
+    for entry in entries:
+        if entry.device_id:
+            device_ids_affected.add(entry.device_id)
+        entity_registry.async_remove(entry.entity_id)
+        _LOGGER.info(
+            "Removed unavailable entity: %s (%s)",
+            entry.entity_id,
+            entry.unique_id,
+        )
+
+    device_registry = dr.async_get(hass)
+    for uid in uids_removed:
+        device = device_registry.async_get_device(
+            identifiers={(DOMAIN, entry_id, uid)}
+        )
+        if device:
+            device_registry.async_remove_device(device.id)
             _LOGGER.info(
-                "Removed unavailable entity: %s (%s)",
-                entry.entity_id,
-                entry.unique_id,
+                "Removed unavailable device for connection UID: %s (device_id: %s)",
+                uid,
+                device.id,
             )
+            device_ids_affected.discard(device.id)
 
-        device_registry = dr.async_get(hass)
-        for uid in uids_removed:
-            device = device_registry.async_get_device(
-                identifiers={(DOMAIN, entry_id, uid)}
+    for dev_id in device_ids_affected:
+        device = device_registry.async_get(dev_id)
+        if not device:
+            continue
+        if not er.async_entries_for_device(entity_registry, dev_id):
+            device_registry.async_remove_device(dev_id)
+            _LOGGER.info(
+                "Removed empty device (no entities left): %s (device_id: %s)",
+                device.name_by_user or device.name,
+                dev_id,
             )
-            if device:
-                device_registry.async_remove_device(device.id)
-                _LOGGER.info(
-                    "Removed unavailable device for connection UID: %s (device_id: %s)",
-                    uid,
-                    device.id,
-                )
-                device_ids_affected.discard(device.id)
-
-        for dev_id in device_ids_affected:
-            device = device_registry.async_get(dev_id)
-            if not device:
-                continue
-            if not er.async_entries_for_device(entity_registry, dev_id):
-                device_registry.async_remove_device(dev_id)
-                _LOGGER.info(
-                    "Removed empty device (no entities left): %s (device_id: %s)",
-                    device.name_by_user or device.name,
-                    dev_id,
-                )
 
     runtime = runtime_from_hass(hass, entry_id)
     if not uids_removed or runtime is None:

--- a/custom_components/fritzbox_vpn/entity_registry.py
+++ b/custom_components/fritzbox_vpn/entity_registry.py
@@ -344,9 +344,7 @@ def remove_orphaned_entities(
 
     device_registry = dr.async_get(hass)
     for uid in uids_removed:
-        device = device_registry.async_get_device(
-            identifiers={(DOMAIN, entry_id, uid)}
-        )
+        device = device_registry.async_get_device(identifiers={(DOMAIN, entry_id, uid)})
         if device:
             device_registry.async_remove_device(device.id)
             _LOGGER.info(

--- a/custom_components/fritzbox_vpn/entity_registry.py
+++ b/custom_components/fritzbox_vpn/entity_registry.py
@@ -107,7 +107,7 @@ def remove_unexpected_entity_entries(
     hass: HomeAssistant,
     entry_id: str,
     *,
-    current_uids: set[str],
+    current_uids: set[str] | None = None,
 ) -> int:
     """Remove shadow entities with broken unique_id formats.
 
@@ -116,10 +116,9 @@ def remove_unexpected_entity_entries(
     UIDs missing from the current poll are kept (temporary reboot / partial
     lists must not destroy registry rows; see issue #37 residual).
 
-    ``current_uids`` is accepted for API compatibility with setup callers; it is
-    not used to delete valid entries.
+    ``current_uids`` is ignored (kept optional for older call sites).
     """
-    _ = current_uids  # API compat; do not delete based on transient poll sets.
+    _ = current_uids
 
     entity_registry = er.async_get(hass)
     to_remove: list[er.RegistryEntry] = []

--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -16,5 +16,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.4b2"
+  "version": "1.2.4b3"
 }

--- a/docs/releases/v1.2.4b3.md
+++ b/docs/releases/v1.2.4b3.md
@@ -1,0 +1,13 @@
+## What's changed
+
+- **Fix (#37 residual):** Temporary VPN absences (e.g. Fritz!Box reboot with a partial connection list) no longer clear platform `known_uids` or delete valid entity-registry rows. Entities stay unavailable until the connection returns — no `_2` duplicates and no `unique_id already exists` spam.
+- **Hardening:** Shadow cleanup on setup only removes broken unique_id formats; dynamic entity add skips UIDs already present in the registry.
+- **UX:** “VPN connection(s) no longer available” is logged only after 3 consecutive successful polls missing that UID.
+
+### 🇩🇪 Deutsch
+
+- **Fix (#37 Residual):** Temporär fehlende VPN-Verbindungen (z. B. Fritz!Box-Reboot mit Teilmenge) leeren `known_uids` nicht mehr und löschen keine gültigen Entity-Registry-Einträge. Entities bleiben unavailable, bis die Verbindung zurückkehrt — keine `_2`-Duplikate und kein `unique_id already exists`-Spam.
+- **Härten:** Shadow-Cleanup beim Setup entfernt nur kaputte unique_id-Formate; dynamisches Entity-Add überspringt UIDs, die schon in der Registry stehen.
+- **UX:** „VPN connection(s) no longer available“ erst nach 3 aufeinanderfolgenden erfolgreichen Polls ohne diese UID.
+
+**Full Changelog:** https://github.com/rosch100/fritzbox-vpn/compare/v1.2.4b2...v1.2.4b3

--- a/docs/releases/v1.2.4b3.md
+++ b/docs/releases/v1.2.4b3.md
@@ -1,13 +1,13 @@
 ## What's changed
 
 - **Fix (#37 residual):** Temporary VPN absences (e.g. Fritz!Box reboot with a partial connection list) no longer clear platform `known_uids` or delete valid entity-registry rows. Entities stay unavailable until the connection returns — no `_2` duplicates and no `unique_id already exists` spam.
-- **Hardening:** Shadow cleanup on setup only removes broken unique_id formats; dynamic entity add skips UIDs already present in the registry.
+- **Hardening:** Shadow cleanup on setup only removes broken unique_id formats. After a partial setup poll, returning connections are added again so HA can restore existing entity IDs.
 - **UX:** “VPN connection(s) no longer available” is logged only after 3 consecutive successful polls missing that UID.
 
 ### 🇩🇪 Deutsch
 
 - **Fix (#37 Residual):** Temporär fehlende VPN-Verbindungen (z. B. Fritz!Box-Reboot mit Teilmenge) leeren `known_uids` nicht mehr und löschen keine gültigen Entity-Registry-Einträge. Entities bleiben unavailable, bis die Verbindung zurückkehrt — keine `_2`-Duplikate und kein `unique_id already exists`-Spam.
-- **Härten:** Shadow-Cleanup beim Setup entfernt nur kaputte unique_id-Formate; dynamisches Entity-Add überspringt UIDs, die schon in der Registry stehen.
+- **Härten:** Shadow-Cleanup beim Setup entfernt nur kaputte unique_id-Formate. Nach Partial-Setup werden zurückkehrende Verbindungen wieder hinzugefügt, damit HA bestehende Entity-IDs wiederherstellen kann.
 - **UX:** „VPN connection(s) no longer available“ erst nach 3 aufeinanderfolgenden erfolgreichen Polls ohne diese UID.
 
 **Full Changelog:** https://github.com/rosch100/fritzbox-vpn/compare/v1.2.4b2...v1.2.4b3

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -265,7 +265,7 @@ def test_entity_id_helpers_edge_cases() -> None:
 
 @pytest.mark.asyncio
 async def test_remove_orphaned_clears_known_uids(hass: HomeAssistant) -> None:
-    """remove_orphaned_entities subtracts UIDs from integration store."""
+    """remove_orphaned_entities clears known_uids only when removing from registry."""
     entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"})
     entry.add_to_hass(hass)
     runtime = FritzboxVpnRuntimeData(
@@ -282,6 +282,8 @@ async def test_remove_orphaned_clears_known_uids(hass: HomeAssistant) -> None:
         config_entry=entry,
     )
     remove_orphaned_entities(hass, entry.entry_id, [entity], remove_from_registry=False)
+    assert entry.runtime_data.known_uids_switch == {"gone", "keep"}
+    remove_orphaned_entities(hass, entry.entry_id, [entity], remove_from_registry=True)
     assert entry.runtime_data.known_uids_switch == {"keep"}
 
 

--- a/tests/test_coordinator_helpers.py
+++ b/tests/test_coordinator_helpers.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from custom_components.fritzbox_vpn.const import ORPHAN_CONFIRM_POLLS
 from custom_components.fritzbox_vpn.coordinator import FritzBoxVPNCoordinator
 from fritzboxvpn.parsing import (
     connection_active_from_api,
@@ -56,7 +57,7 @@ def test_extract_box_connections_alternate_paths() -> None:
 
 @pytest.mark.asyncio
 async def test_coordinator_removed_vpn_triggers_callback(hass: HomeAssistant) -> None:
-    """Removed VPN UIDs invoke on_orphaned_removed callback."""
+    """Removed VPN UIDs invoke on_orphaned_removed after confirm polls."""
     entry = MockConfigEntry(
         domain="fritzbox_vpn",
         data={"host": MOCK_HOST, "username": "u", "password": "p"},
@@ -70,6 +71,10 @@ async def test_coordinator_removed_vpn_triggers_callback(hass: HomeAssistant) ->
     coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
         return_value={"conn-abc": MOCK_VPN_CONNECTIONS["conn-abc"]}
     )
+
+    for _ in range(ORPHAN_CONFIRM_POLLS - 1):
+        await coordinator._async_update_data()
+    callback.assert_not_called()
 
     await coordinator._async_update_data()
     callback.assert_called_once()

--- a/tests/test_entity_lifecycle_reboot.py
+++ b/tests/test_entity_lifecycle_reboot.py
@@ -168,29 +168,30 @@ async def test_uid_loss_and_return_does_not_readd_entities(
 
 
 @pytest.mark.asyncio
-async def test_add_new_skips_uids_already_in_entity_registry(
+async def test_partial_setup_adds_entities_when_missing_uid_returns(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
-    """Defense-in-depth: do not async_add_entities for UIDs already in the registry."""
+    """After setup with a partial poll, returning UIDs must be added (HA restores IDs)."""
     mock_config_entry.add_to_hass(hass)
     coordinator = FritzBoxVPNCoordinator(
         hass, mock_config_entry.data, None, mock_config_entry.entry_id
     )
-    coordinator.async_set_updated_data({})
+    # Simulate reload/setup during reboot: only one connection visible.
+    partial = {"conn-abc": MOCK_VPN_CONNECTIONS["conn-abc"]}
+    coordinator.async_set_updated_data(partial)
     coordinator.last_update_success = True
-    runtime = FritzboxVpnRuntimeData(coordinator=coordinator)
-    # Pretend tracking was cleared incorrectly while registry still has the entity.
-    runtime.known_uids_switch = set()
-    mock_config_entry.runtime_data = runtime
+    mock_config_entry.runtime_data = FritzboxVpnRuntimeData(coordinator=coordinator)
     mock_config_entry.mock_state(hass, ConfigEntryState.LOADED)
 
+    # Registry still has the temporarily missing connection from before reboot.
     registry = er.async_get(hass)
-    registry.async_get_or_create(
-        "switch",
-        DOMAIN,
-        vpn_unique_id("conn-abc", UNIQUE_ID_SUFFIX_SWITCH),
-        config_entry=mock_config_entry,
-    )
+    for uid in MOCK_VPN_CONNECTIONS:
+        registry.async_get_or_create(
+            "switch",
+            DOMAIN,
+            vpn_unique_id(uid, UNIQUE_ID_SUFFIX_SWITCH),
+            config_entry=mock_config_entry,
+        )
 
     add_calls: list[list] = []
 
@@ -206,14 +207,21 @@ async def test_add_new_skips_uids_already_in_entity_registry(
             for uid in uids
         ],
     )
-    assert add_calls == [[]]  # empty initial data
+    assert len(add_calls) == 1
+    assert len(add_calls[0]) == 1
+    assert mock_config_entry.runtime_data.known_uids_switch == {"conn-abc"}
 
-    coordinator.async_set_updated_data({"conn-abc": MOCK_VPN_CONNECTIONS["conn-abc"]})
+    # Full set returns — must add the missing UID (registry presence must not block).
+    coordinator.async_set_updated_data(dict(MOCK_VPN_CONNECTIONS))
     await hass.async_block_till_done()
 
-    # UID was adopted into known_uids without a second add.
-    assert "conn-abc" in mock_config_entry.runtime_data.known_uids_switch
-    assert len(add_calls) == 1
+    assert mock_config_entry.runtime_data.known_uids_switch == set(
+        MOCK_VPN_CONNECTIONS.keys()
+    )
+    assert len(add_calls) == 2
+    assert {e.unique_id for e in add_calls[1]} == {
+        vpn_unique_id("conn-def", UNIQUE_ID_SUFFIX_SWITCH)
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_entity_lifecycle_reboot.py
+++ b/tests/test_entity_lifecycle_reboot.py
@@ -208,9 +208,7 @@ async def test_add_new_skips_uids_already_in_entity_registry(
     )
     assert add_calls == [[]]  # empty initial data
 
-    coordinator.async_set_updated_data(
-        {"conn-abc": MOCK_VPN_CONNECTIONS["conn-abc"]}
-    )
+    coordinator.async_set_updated_data({"conn-abc": MOCK_VPN_CONNECTIONS["conn-abc"]})
     await hass.async_block_till_done()
 
     # UID was adopted into known_uids without a second add.

--- a/tests/test_entity_lifecycle_reboot.py
+++ b/tests/test_entity_lifecycle_reboot.py
@@ -21,6 +21,7 @@ from custom_components.fritzbox_vpn.models import FritzboxVpnRuntimeData
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.update_coordinator import UpdateFailed
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from tests.fixtures import MOCK_HOST, MOCK_VPN_CONNECTIONS
@@ -97,9 +98,7 @@ async def test_shadow_cleanup_keeps_valid_uids_missing_from_current_poll(
         config_entry=entry,
     )
 
-    removed = remove_unexpected_entity_entries(
-        hass, entry.entry_id, current_uids={"conn-abc"}
-    )
+    removed = remove_unexpected_entity_entries(hass, entry.entry_id)
 
     assert removed == 1
     assert registry.async_get(valid_missing.entity_id) is not None
@@ -125,29 +124,25 @@ async def test_uid_loss_and_return_does_not_readd_entities(
     def _async_add_entities(entities, **kwargs):
         add_calls.append(list(entities))
 
+    def _create_entities(coord, uids):
+        entities = []
+        for uid in uids:
+            entity = MagicMock()
+            entity.unique_id = vpn_unique_id(uid, UNIQUE_ID_SUFFIX_SWITCH)
+            entity._connection_uid = uid
+            entities.append(entity)
+        return entities
+
     await setup_vpn_platform(
         mock_config_entry,
         _async_add_entities,
         platform="switch",
-        create_entities=lambda coord, uids: [
-            MagicMock(unique_id=vpn_unique_id(uid, UNIQUE_ID_SUFFIX_SWITCH))
-            for uid in uids
-        ],
+        create_entities=_create_entities,
     )
     assert len(add_calls) == 1
     assert len(add_calls[0]) == len(MOCK_VPN_CONNECTIONS)
     known = mock_config_entry.runtime_data.known_uids_switch
     assert known == set(MOCK_VPN_CONNECTIONS.keys())
-
-    # Register entities so defense-in-depth can see them in the registry.
-    registry = er.async_get(hass)
-    for uid in MOCK_VPN_CONNECTIONS:
-        registry.async_get_or_create(
-            "switch",
-            DOMAIN,
-            vpn_unique_id(uid, UNIQUE_ID_SUFFIX_SWITCH),
-            config_entry=mock_config_entry,
-        )
 
     # Simulate temporary loss of one connection (reboot partial poll).
     partial = {"conn-abc": MOCK_VPN_CONNECTIONS["conn-abc"]}
@@ -198,14 +193,22 @@ async def test_partial_setup_adds_entities_when_missing_uid_returns(
     def _async_add_entities(entities, **kwargs):
         add_calls.append(list(entities))
 
+    def _create_entities(coord, uids):
+        entities = []
+        for uid in uids:
+            if coord.data and uid not in coord.data:
+                continue
+            entity = MagicMock()
+            entity.unique_id = vpn_unique_id(uid, UNIQUE_ID_SUFFIX_SWITCH)
+            entity._connection_uid = uid
+            entities.append(entity)
+        return entities
+
     await setup_vpn_platform(
         mock_config_entry,
         _async_add_entities,
         platform="switch",
-        create_entities=lambda coord, uids: [
-            MagicMock(unique_id=vpn_unique_id(uid, UNIQUE_ID_SUFFIX_SWITCH))
-            for uid in uids
-        ],
+        create_entities=_create_entities,
     )
     assert len(add_calls) == 1
     assert len(add_calls[0]) == 1
@@ -248,7 +251,50 @@ async def test_coordinator_orphan_warning_debounced(hass: HomeAssistant) -> None
     await coordinator._async_update_data()
     callback.assert_called_once()
     assert callback.call_args.args[1] == {"conn-abc"}
+    assert coordinator._uid_names.get("conn-def") == "Guest VPN"
 
     # Further misses for the same UID must not re-fire the callback.
+    await coordinator._async_update_data()
+    callback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_update_failed_resets_orphan_miss_streak(
+    hass: HomeAssistant,
+) -> None:
+    """Transport failures must reset miss streaks (consecutive successful polls)."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": MOCK_HOST, "username": "u", "password": "p"},
+    )
+    callback = MagicMock()
+    coordinator = FritzBoxVPNCoordinator(
+        hass, entry.data, None, entry.entry_id, on_orphaned_removed=callback
+    )
+    coordinator.async_set_updated_data(dict(MOCK_VPN_CONNECTIONS))
+    coordinator.fritz_session = MagicMock()
+    coordinator.fritz_session.invalidate_session = MagicMock()
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        return_value={"conn-abc": MOCK_VPN_CONNECTIONS["conn-abc"]}
+    )
+
+    for _ in range(ORPHAN_CONFIRM_POLLS - 1):
+        await coordinator._async_update_data()
+    assert coordinator._missing_uid_counts.get("conn-def") == ORPHAN_CONFIRM_POLLS - 1
+
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        side_effect=ConnectionError("connect refused")
+    )
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+    assert coordinator._missing_uid_counts == {}
+
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        return_value={"conn-abc": MOCK_VPN_CONNECTIONS["conn-abc"]}
+    )
+    for _ in range(ORPHAN_CONFIRM_POLLS - 1):
+        await coordinator._async_update_data()
+    callback.assert_not_called()
+
     await coordinator._async_update_data()
     callback.assert_called_once()

--- a/tests/test_entity_lifecycle_reboot.py
+++ b/tests/test_entity_lifecycle_reboot.py
@@ -1,0 +1,248 @@
+"""Regression tests for #37 residual: entity lifecycle across temporary UID loss."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from custom_components.fritzbox_vpn.const import (
+    DOMAIN,
+    ORPHAN_CONFIRM_POLLS,
+    UNIQUE_ID_PREFIX,
+    UNIQUE_ID_SUFFIX_SWITCH,
+)
+from custom_components.fritzbox_vpn.coordinator import FritzBoxVPNCoordinator
+from custom_components.fritzbox_vpn.entity import setup_vpn_platform, vpn_unique_id
+from custom_components.fritzbox_vpn.entity_registry import (
+    remove_orphaned_entities,
+    remove_unexpected_entity_entries,
+)
+from custom_components.fritzbox_vpn.models import FritzboxVpnRuntimeData
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from tests.fixtures import MOCK_HOST, MOCK_VPN_CONNECTIONS
+
+
+@pytest.mark.asyncio
+async def test_remove_orphaned_keeps_known_uids_when_not_removing_registry(
+    hass: HomeAssistant,
+) -> None:
+    """Temporary orphan cleanup must not clear known_uids (issue #37 residual)."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"})
+    entry.add_to_hass(hass)
+    runtime = FritzboxVpnRuntimeData(coordinator=type("C", (), {"data": {}})())
+    runtime.known_uids_switch = {"gone", "keep"}
+    entry.runtime_data = runtime
+    entry.mock_state(hass, ConfigEntryState.LOADED)
+    entity_registry = er.async_get(hass)
+    entity = entity_registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}gone_switch",
+        config_entry=entry,
+    )
+
+    remove_orphaned_entities(hass, entry.entry_id, [entity], remove_from_registry=False)
+
+    assert entry.runtime_data.known_uids_switch == {"gone", "keep"}
+    assert entity_registry.async_get(entity.entity_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_remove_orphaned_clears_known_uids_when_removing_registry(
+    hass: HomeAssistant,
+) -> None:
+    """Manual/registry removal still clears known_uids for removed connections."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"})
+    entry.add_to_hass(hass)
+    runtime = FritzboxVpnRuntimeData(coordinator=type("C", (), {"data": {}})())
+    runtime.known_uids_switch = {"gone", "keep"}
+    entry.runtime_data = runtime
+    entry.mock_state(hass, ConfigEntryState.LOADED)
+    entity_registry = er.async_get(hass)
+    entity = entity_registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}gone_switch",
+        config_entry=entry,
+    )
+
+    remove_orphaned_entities(hass, entry.entry_id, [entity], remove_from_registry=True)
+
+    assert entry.runtime_data.known_uids_switch == {"keep"}
+    assert entity_registry.async_get(entity.entity_id) is None
+
+
+@pytest.mark.asyncio
+async def test_shadow_cleanup_keeps_valid_uids_missing_from_current_poll(
+    hass: HomeAssistant,
+) -> None:
+    """Setup shadow cleanup must not delete valid entities for temporarily missing UIDs."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"})
+    entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    valid_missing = registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        vpn_unique_id("conn-def", UNIQUE_ID_SUFFIX_SWITCH),
+        config_entry=entry,
+    )
+    invalid_shadow = registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}conn-abc",  # missing platform suffix
+        config_entry=entry,
+    )
+
+    removed = remove_unexpected_entity_entries(
+        hass, entry.entry_id, current_uids={"conn-abc"}
+    )
+
+    assert removed == 1
+    assert registry.async_get(valid_missing.entity_id) is not None
+    assert registry.async_get(invalid_shadow.entity_id) is None
+
+
+@pytest.mark.asyncio
+async def test_uid_loss_and_return_does_not_readd_entities(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Full → partial → full poll must keep known_uids and not re-add entities."""
+    mock_config_entry.add_to_hass(hass)
+    coordinator = FritzBoxVPNCoordinator(
+        hass, mock_config_entry.data, None, mock_config_entry.entry_id
+    )
+    coordinator.async_set_updated_data(dict(MOCK_VPN_CONNECTIONS))
+    coordinator.last_update_success = True
+    mock_config_entry.runtime_data = FritzboxVpnRuntimeData(coordinator=coordinator)
+    mock_config_entry.mock_state(hass, ConfigEntryState.LOADED)
+
+    add_calls: list[list] = []
+
+    def _async_add_entities(entities, **kwargs):
+        add_calls.append(list(entities))
+
+    await setup_vpn_platform(
+        mock_config_entry,
+        _async_add_entities,
+        platform="switch",
+        create_entities=lambda coord, uids: [
+            MagicMock(unique_id=vpn_unique_id(uid, UNIQUE_ID_SUFFIX_SWITCH))
+            for uid in uids
+        ],
+    )
+    assert len(add_calls) == 1
+    assert len(add_calls[0]) == len(MOCK_VPN_CONNECTIONS)
+    known = mock_config_entry.runtime_data.known_uids_switch
+    assert known == set(MOCK_VPN_CONNECTIONS.keys())
+
+    # Register entities so defense-in-depth can see them in the registry.
+    registry = er.async_get(hass)
+    for uid in MOCK_VPN_CONNECTIONS:
+        registry.async_get_or_create(
+            "switch",
+            DOMAIN,
+            vpn_unique_id(uid, UNIQUE_ID_SUFFIX_SWITCH),
+            config_entry=mock_config_entry,
+        )
+
+    # Simulate temporary loss of one connection (reboot partial poll).
+    partial = {"conn-abc": MOCK_VPN_CONNECTIONS["conn-abc"]}
+    coordinator.async_set_updated_data(partial)
+    await hass.async_block_till_done()
+    assert mock_config_entry.runtime_data.known_uids_switch == set(
+        MOCK_VPN_CONNECTIONS.keys()
+    )
+    assert len(add_calls) == 1
+
+    # Connection returns — must not create a second entity batch.
+    coordinator.async_set_updated_data(dict(MOCK_VPN_CONNECTIONS))
+    await hass.async_block_till_done()
+    assert mock_config_entry.runtime_data.known_uids_switch == set(
+        MOCK_VPN_CONNECTIONS.keys()
+    )
+    assert len(add_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_add_new_skips_uids_already_in_entity_registry(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Defense-in-depth: do not async_add_entities for UIDs already in the registry."""
+    mock_config_entry.add_to_hass(hass)
+    coordinator = FritzBoxVPNCoordinator(
+        hass, mock_config_entry.data, None, mock_config_entry.entry_id
+    )
+    coordinator.async_set_updated_data({})
+    coordinator.last_update_success = True
+    runtime = FritzboxVpnRuntimeData(coordinator=coordinator)
+    # Pretend tracking was cleared incorrectly while registry still has the entity.
+    runtime.known_uids_switch = set()
+    mock_config_entry.runtime_data = runtime
+    mock_config_entry.mock_state(hass, ConfigEntryState.LOADED)
+
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        vpn_unique_id("conn-abc", UNIQUE_ID_SUFFIX_SWITCH),
+        config_entry=mock_config_entry,
+    )
+
+    add_calls: list[list] = []
+
+    def _async_add_entities(entities, **kwargs):
+        add_calls.append(list(entities))
+
+    await setup_vpn_platform(
+        mock_config_entry,
+        _async_add_entities,
+        platform="switch",
+        create_entities=lambda coord, uids: [
+            MagicMock(unique_id=vpn_unique_id(uid, UNIQUE_ID_SUFFIX_SWITCH))
+            for uid in uids
+        ],
+    )
+    assert add_calls == [[]]  # empty initial data
+
+    coordinator.async_set_updated_data(
+        {"conn-abc": MOCK_VPN_CONNECTIONS["conn-abc"]}
+    )
+    await hass.async_block_till_done()
+
+    # UID was adopted into known_uids without a second add.
+    assert "conn-abc" in mock_config_entry.runtime_data.known_uids_switch
+    assert len(add_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_coordinator_orphan_warning_debounced(hass: HomeAssistant) -> None:
+    """Orphan callback/warning only after ORPHAN_CONFIRM_POLLS consecutive misses."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": MOCK_HOST, "username": "u", "password": "p"},
+    )
+    callback = MagicMock()
+    coordinator = FritzBoxVPNCoordinator(
+        hass, entry.data, None, entry.entry_id, on_orphaned_removed=callback
+    )
+    coordinator.async_set_updated_data(dict(MOCK_VPN_CONNECTIONS))
+    coordinator.fritz_session = AsyncMock()
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        return_value={"conn-abc": MOCK_VPN_CONNECTIONS["conn-abc"]}
+    )
+
+    for _ in range(ORPHAN_CONFIRM_POLLS - 1):
+        await coordinator._async_update_data()
+    callback.assert_not_called()
+
+    await coordinator._async_update_data()
+    callback.assert_called_once()
+    assert callback.call_args.args[1] == {"conn-abc"}
+
+    # Further misses for the same UID must not re-fire the callback.
+    await coordinator._async_update_data()
+    callback.assert_called_once()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Behebt den Restfehler von #37 auf `1.2.4b2`: nach Fritz!-Reboot bzw. temporär unvollständiger VPN-Liste entstanden `_2`-Entities und `unique_id already exists`-Logs.

**Ursache:** Auto-Cleanup leerte `known_uids` bei fehlenden UIDs; Shadow-Cleanup löschte gültige Registry-Einträge bei Teilmengen-Polls; danach wurden Entities erneut hinzugefügt.

**Änderungen (v1.2.4b3):**
- `known_uids` nur noch clearen, wenn Entities wirklich aus der Registry entfernt werden (kein Auto-Cleanup mehr bei temporärer Abwesenheit)
- Shadow-Cleanup entfernt nur kaputte unique_id-Formate (nicht temporär fehlende UIDs)
- Dynamisches Entity-Add nach Partial-Setup fügt zurückkehrende UIDs wieder hinzu (HA stellt bestehende entity_ids wieder her); Schutz vor Live-Duplikaten ausschließlich über stabile `known_uids`
- Orphan-Warnung erst nach 3 aufeinanderfolgenden erfolgreichen Polls ohne UID (mit Namens-Cache)
- Regressionstests in `tests/test_entity_lifecycle_reboot.py`

Fixes #37

## Test plan

- [x] Lokal: `ruff check` / `ruff format --check` grün
- [x] Lokal: `pytest tests/ --cov=custom_components/fritzbox_vpn -q` — 190 passed, Coverage 91%
- [ ] CI grün (`Ruff`, `pytest`, `HACS validate`, `hassfest`)
- [ ] Feldtest: Fritz!Box rebooten → Entities werden nach Recovery wieder available, ohne `_2` und ohne unique_id-Warnungen

## Checklist

- [ ] Copilot Code Review abgewartet (läuft automatisch bei Push)
- [x] Keine Secrets oder Zugangsdaten im Diff
- [x] SSDP-Helfer nur in `ssdp_unique_id.py` (keine Duplikate in `config_flow`)
- [x] Version in `manifest.json` auf `1.2.4b3` angepasst (+ Release Notes)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fbe0c-ebc4-738b-a884-9850b8edd290?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fbe0c-ebc4-738b-a884-9850b8edd290&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VPN entities now tolerate temporary polling gaps without premature removal.
  * Missing connections require three consecutive successful polls before removal alerts.
  * Restored connections retain existing entities and avoid duplicates.
  * Registry cleanup preserves valid entities and removes only invalid entries.

* **Documentation**
  * Added release notes for version 1.2.4b3.

* **Chores**
  * Updated the integration version to 1.2.4b3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->