### PR TITLE
fix: recover VPN entities after Fritz!Box reboot (v1.2.4b4)

### DIFF
--- a/custom_components/fritzbox_vpn/__init__.py
+++ b/custom_components/fritzbox_vpn/__init__.py
@@ -31,6 +31,7 @@ from .entity_registry import (
     repair_entity_id_suffixes,
     repair_entity_ids,
     repair_legacy_entity_object_ids,
+    repair_orphan_base_suffix_merges,
 )
 from .models import FritzboxVpnConfigEntry, FritzboxVpnRuntimeData
 
@@ -157,14 +158,20 @@ def _cleanup_empty_connection_devices(hass: HomeAssistant, entry_id: str) -> int
 
 
 def _repair_entity_ids_before_platform_setup(hass: HomeAssistant, entry_id: str) -> int:
-    """Repair numeric entity_id suffixes (_2, _3, …) before platform setup."""
+    """Heal orphan-base+_2 pairs, then non-destructive numeric suffix repairs."""
+    merge_count, _ = repair_orphan_base_suffix_merges(hass, entry_id)
+    if merge_count:
+        _LOGGER.warning(
+            "Merged %d orphan base/_2 entity pair(s) before platform setup",
+            merge_count,
+        )
     repaired_count, _ = repair_entity_id_suffixes(hass, entry_id)
     if repaired_count:
         _LOGGER.info(
             "Repaired %d numeric entity ID suffix(es) before platform setup",
             repaired_count,
         )
-    return repaired_count
+    return merge_count + repaired_count
 
 
 async def async_migrate_entry(

--- a/custom_components/fritzbox_vpn/config_flow.py
+++ b/custom_components/fritzbox_vpn/config_flow.py
@@ -30,8 +30,10 @@ from .const import (
     password_from_sources,
 )
 from .entity_registry import (
+    count_repairable_entity_issues,
     get_entity_id_suffix_repairs,
     get_legacy_entity_object_id_repairs,
+    get_orphan_base_suffix_merges,
     get_orphaned_entity_entries,
     remove_orphaned_entities,
     repair_entity_ids,
@@ -330,20 +332,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             to_remove, error_key = get_orphaned_entity_entries(
                 self.hass, self._config_entry.entry_id
             )
-            registry = er.async_get(self.hass)
-            legacy_repairs = get_legacy_entity_object_id_repairs(
+            repair_count = count_repairable_entity_issues(
                 self.hass, self._config_entry.entry_id
             )
-            suffix_repairs = get_entity_id_suffix_repairs(
-                registry, self._config_entry.entry_id
-            )
             has_cleanup_action = error_key is None and bool(to_remove)
-            has_repair_action = bool(legacy_repairs) or bool(suffix_repairs)
-            return (
-                has_cleanup_action,
-                has_repair_action,
-                len(legacy_repairs) + len(suffix_repairs),
-            )
+            has_repair_action = repair_count > 0
+            return (has_cleanup_action, has_repair_action, repair_count)
         except Exception as err:
             _LOGGER.exception(
                 "Failed to evaluate available options actions for entry %s: %s",
@@ -449,8 +443,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         entry_id = config_entry.entry_id
         registry = er.async_get(self.hass)
         legacy_repairs = get_legacy_entity_object_id_repairs(self.hass, entry_id)
+        merge_repairs = get_orphan_base_suffix_merges(self.hass, entry_id)
         suffix_repairs = get_entity_id_suffix_repairs(registry, entry_id)
-        pending = [*legacy_repairs, *suffix_repairs]
+        pending = [*legacy_repairs, *merge_repairs, *suffix_repairs]
 
         async def on_repair(confirmed_entry_id: str) -> None:
             count, _ = repair_entity_ids(self.hass, confirmed_entry_id)

--- a/custom_components/fritzbox_vpn/const.py
+++ b/custom_components/fritzbox_vpn/const.py
@@ -23,6 +23,10 @@ RETRY_AFTER_SECONDS = 60
 # Consecutive successful polls a UID must be missing before we treat it as removed
 # (avoids reboot/partial-list noise; see issue #37 residual).
 ORPHAN_CONFIRM_POLLS = 3
+# After connectivity outage: minimum recovery window and stable non-empty polls
+# before orphan tracking resumes (see issue #37 / reboot empty-list churn).
+RECOVERY_STABLE_POLLS = 2
+RECOVERY_MIN_INTERVAL_FACTOR = 3
 
 ATTR_UID = "uid"
 ATTR_VPN_UID = "vpn_uid"
@@ -48,8 +52,41 @@ SERVICE_REMOVE_UNAVAILABLE_ENTITIES = "remove_unavailable_entities"
 SERVICE_REPAIR_ENTITY_ID_SUFFIXES = "repair_entity_id_suffixes"
 CONF_CONFIG_ENTRY_ID = "config_entry_id"
 
-LOG_MSG_VPN_CONNECTIONS_REMOVED = "VPN connection(s) no longer available on the %s; related entities will show as unavailable: %s"
-LOG_MSG_VPN_CONNECTIONS_REMOVED_HINT = "You can remove obsolete entities under Settings > Devices & Services > Entities (filter by Fritz!Box VPN)."
+LOG_MSG_VPN_CONNECTIONS_REMOVED = (
+    "VPN connection(s) no longer available on the %s; "
+    "related entities will show as unavailable: %s (uids=%s)"
+)
+LOG_MSG_VPN_CONNECTIONS_REMOVED_HINT = (
+    "You can remove obsolete entities under Settings > Devices & Services > "
+    "Entities (filter by Fritz!Box VPN), or use the cleanup option."
+)
+LOG_MSG_RECOVERY_ARMED = (
+    "Connectivity outage for %s; recovery window armed for at least %ss "
+    "(seen_uids=%d). Orphan tracking paused until stable non-empty polls."
+)
+LOG_MSG_RECOVERY_CLEARED = (
+    "Recovery window cleared for %s after %d stable non-empty poll(s)."
+)
+LOG_MSG_EMPTY_DURING_RECOVERY = (
+    "Empty VPN list from %s while recovering after outage "
+    "(seen_uids=%d); treating as outage, not connection removal."
+)
+LOG_MSG_UID_DELTA = "VPN UID delta on %s: added=%s removed=%s"
+LOG_MSG_UID_REMAP = (
+    "VPN connection UID remapped after outage recovery on %s: %s → %s (name=%r)"
+)
+LOG_MSG_UID_REMAP_REFUSED = (
+    "VPN UID set changed after outage on %s but name bijection remap was refused "
+    "(%s). added=%s removed=%s"
+)
+LOG_MSG_SESSION_MODE_FALLBACK = (
+    "FritzWireguard module unavailable; using fritzboxvpn web-API fallback "
+    "for host %s. Prefer installing a fritzconnection build with WireGuard support."
+)
+LOG_MSG_ORPHAN_BASE_MERGE = (
+    "Merged orphan base entity_id with live suffixed entity: %s → %s "
+    "(removed orphan unique_id=%s)"
+)
 
 MANUFACTURER_AVM = "AVM"
 MODEL_FRITZBOX = "Fritz!Box"

--- a/custom_components/fritzbox_vpn/coordinator.py
+++ b/custom_components/fritzbox_vpn/coordinator.py
@@ -1,7 +1,10 @@
 """DataUpdateCoordinator for FritzBox VPN integration."""
 
+from __future__ import annotations
+
 import inspect
 import logging
+import time
 from collections.abc import Callable
 from datetime import timedelta
 from typing import Any
@@ -21,10 +24,18 @@ from .const import (
     CONF_UPDATE_INTERVAL,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
+    LOG_MSG_EMPTY_DURING_RECOVERY,
+    LOG_MSG_RECOVERY_ARMED,
+    LOG_MSG_RECOVERY_CLEARED,
+    LOG_MSG_UID_DELTA,
+    LOG_MSG_UID_REMAP,
+    LOG_MSG_UID_REMAP_REFUSED,
     LOG_MSG_VPN_CONNECTIONS_REMOVED,
     LOG_MSG_VPN_CONNECTIONS_REMOVED_HINT,
     NAME_FRITZBOX,
     ORPHAN_CONFIRM_POLLS,
+    RECOVERY_MIN_INTERVAL_FACTOR,
+    RECOVERY_STABLE_POLLS,
     RETRY_AFTER_SECONDS,
     STATUS_CONNECTED,
     STATUS_DISABLED,
@@ -34,7 +45,9 @@ from .const import (
     UPDATE_INTERVAL_MIN,
     host_from_config,
 )
+from .entity_registry import remap_connection_uids
 from .fritzconnection_session import FritzConnectionVPNSession
+from .uid_identity import name_bijection_uid_remap
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,6 +96,14 @@ def _resolve_update_interval_seconds(
     return normalize_update_interval(value)
 
 
+def recovery_window_seconds(update_interval_seconds: int) -> int:
+    """Minimum recovery window after connectivity outage."""
+    return max(
+        RECOVERY_MIN_INTERVAL_FACTOR * update_interval_seconds,
+        RECOVERY_MIN_INTERVAL_FACTOR * RETRY_AFTER_SECONDS,
+    )
+
+
 class FritzBoxVPNCoordinator(DataUpdateCoordinator):
     """Coordinator for FritzBox VPN data."""
 
@@ -95,6 +116,7 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
         on_orphaned_removed: Callable[[str, set[str]], None] | None = None,
     ):
         update_interval_seconds = _resolve_update_interval_seconds(config, options)
+        self._update_interval_seconds = update_interval_seconds
 
         super().__init__(
             hass,
@@ -117,12 +139,25 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
         self._missing_uid_counts: dict[str, int] = {}
         self._confirmed_orphan_uids: set[str] = set()
         self._uid_names: dict[str, str] = {}
+        self._uid_remap: dict[str, str] = {}
+        self._recovering_until: float | None = None
+        self._recovery_stable_polls: int = 0
+
+    def resolve_connection_uid(self, connection_uid: str) -> str:
+        """Map a pre-remap entity UID to the current coordinator data key."""
+        uid = connection_uid
+        seen: set[str] = set()
+        while uid in self._uid_remap and uid not in seen:
+            seen.add(uid)
+            uid = self._uid_remap[uid]
+        return uid
 
     def get_vpn_status(self, connection_uid: str) -> str:
         """Get the textual status of a VPN connection."""
-        if not self.data or connection_uid not in self.data:
+        resolved = self.resolve_connection_uid(connection_uid)
+        if not self.data or resolved not in self.data:
             return STATUS_UNKNOWN
-        conn = self.data[connection_uid]
+        conn = self.data[resolved]
         active = conn.get(API_KEY_ACTIVE, False)
         connected = conn.get(API_KEY_CONNECTED, False)
         if not active:
@@ -171,6 +206,121 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
         """Clear in-progress miss counts so confirmations require consecutive successes."""
         self._missing_uid_counts.clear()
 
+    def _in_recovery(self) -> bool:
+        """True while post-outage recovery window is active."""
+        return self._recovering_until is not None
+
+    def _arm_recovery(self) -> None:
+        """Start or extend the post-outage recovery window."""
+        if self.data:
+            self._seen_uids |= set(self.data.keys())
+            self._remember_connection_names(self.data)
+        duration = recovery_window_seconds(self._update_interval_seconds)
+        until = time.monotonic() + duration
+        was_recovering = self._recovering_until is not None
+        if self._recovering_until is None or until > self._recovering_until:
+            self._recovering_until = until
+        self._recovery_stable_polls = 0
+        self._reset_orphan_miss_streaks()
+        if not was_recovering:
+            _LOGGER.warning(
+                LOG_MSG_RECOVERY_ARMED,
+                host_from_config(self.config),
+                duration,
+                len(self._seen_uids),
+            )
+
+    def _note_successful_poll(self, connections: dict[str, Any]) -> None:
+        """Advance or clear recovery based on non-empty successful polls."""
+        if self._recovering_until is None:
+            return
+        if not connections:
+            self._recovery_stable_polls = 0
+            return
+        self._recovery_stable_polls += 1
+        if (
+            time.monotonic() >= self._recovering_until
+            and self._recovery_stable_polls >= RECOVERY_STABLE_POLLS
+        ):
+            self._recovering_until = None
+            self._recovery_stable_polls = 0
+            _LOGGER.info(
+                LOG_MSG_RECOVERY_CLEARED,
+                host_from_config(self.config),
+                RECOVERY_STABLE_POLLS,
+            )
+
+    def _log_uid_delta(self, current_uids: set[str]) -> None:
+        """Log added/removed UIDs with cached names when the set changes."""
+        if not self._seen_uids:
+            return
+        added = sorted(current_uids - self._seen_uids)
+        removed = sorted(self._seen_uids - current_uids)
+        if not added and not removed:
+            return
+
+        def _labeled(uids: list[str]) -> list[str]:
+            return [f"{self._uid_names.get(uid, uid)} ({uid})" for uid in uids]
+
+        _LOGGER.info(
+            LOG_MSG_UID_DELTA,
+            host_from_config(self.config),
+            _labeled(added),
+            _labeled(removed),
+        )
+
+    def _apply_uid_remap_if_needed(self, connections: dict[str, Any]) -> None:
+        """During recovery, remap registry UIDs when names form a 1:1 bijection."""
+        if not self._in_recovery() or not self.entry_id or not connections:
+            return
+        current_uids = set(connections.keys())
+        removed = self._seen_uids - current_uids
+        added = current_uids - self._seen_uids
+        if not removed or not added:
+            return
+
+        mapping, reason = name_bijection_uid_remap(
+            removed, added, self._uid_names, connections
+        )
+        host = host_from_config(self.config)
+        if mapping is None:
+            _LOGGER.error(
+                LOG_MSG_UID_REMAP_REFUSED,
+                host,
+                reason or "unknown",
+                sorted(added),
+                sorted(removed),
+            )
+            return
+
+        remapped = remap_connection_uids(self.hass, self.entry_id, mapping)
+        for old_uid, new_uid in mapping.items():
+            self._uid_remap[old_uid] = new_uid
+            self._seen_uids.discard(old_uid)
+            self._seen_uids.add(new_uid)
+            name = self._uid_names.pop(old_uid, None)
+            if name is not None:
+                self._uid_names[new_uid] = name
+            else:
+                payload = connections.get(new_uid)
+                if isinstance(payload, dict) and payload.get(API_KEY_NAME):
+                    self._uid_names[new_uid] = str(payload[API_KEY_NAME])
+            self._missing_uid_counts.pop(old_uid, None)
+            self._confirmed_orphan_uids.discard(old_uid)
+            _LOGGER.warning(
+                LOG_MSG_UID_REMAP,
+                host,
+                old_uid,
+                new_uid,
+                self._uid_names.get(new_uid, new_uid),
+            )
+        if remapped:
+            _LOGGER.info(
+                "Remapped %d entity unique_id(s) after outage recovery for entry %s",
+                remapped,
+                self.entry_id,
+            )
+
     def _track_missing_uids(self, current_uids: set[str]) -> set[str]:
         """Return UIDs newly confirmed missing after ORPHAN_CONFIRM_POLLS polls."""
         if self.data:
@@ -194,46 +344,76 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
         """Fetch latest VPN data from Fritz!Box."""
         try:
             connections = await self.fritz_session.async_get_vpn_connections()
+            had_connections = bool(self._seen_uids) or bool(self.data)
+            if not connections and self._in_recovery() and had_connections:
+                _LOGGER.warning(
+                    LOG_MSG_EMPTY_DURING_RECOVERY,
+                    host_from_config(self.config),
+                    len(self._seen_uids) or len(self.data or {}),
+                )
+                self._reset_orphan_miss_streaks()
+                self._recovery_stable_polls = 0
+                raise UpdateFailed(
+                    "VPN list empty while recovering after connectivity outage",
+                    retry_after=RETRY_AFTER_SECONDS,
+                )
+
             current_uids = set(connections.keys())
             self._remember_connection_names(connections)
-            newly_confirmed = self._track_missing_uids(current_uids)
+            self._log_uid_delta(current_uids)
+            self._apply_uid_remap_if_needed(connections)
+
+            if self._in_recovery():
+                self._reset_orphan_miss_streaks()
+                if self.data:
+                    self._seen_uids |= set(self.data.keys())
+                self._seen_uids |= current_uids
+                newly_confirmed: set[str] = set()
+            else:
+                newly_confirmed = self._track_missing_uids(current_uids)
+
             if newly_confirmed:
                 names = [self._uid_names.get(uid, uid) for uid in newly_confirmed]
                 _LOGGER.warning(
                     LOG_MSG_VPN_CONNECTIONS_REMOVED,
                     NAME_FRITZBOX,
                     names or list(newly_confirmed),
+                    sorted(newly_confirmed),
                 )
                 _LOGGER.info(LOG_MSG_VPN_CONNECTIONS_REMOVED_HINT)
                 if self._on_orphaned_removed and self.entry_id:
                     self._on_orphaned_removed(self.entry_id, current_uids)
+
+            self._note_successful_poll(connections)
             self._reauth_scheduled = False
             return connections
+        except UpdateFailed:
+            raise
         except (ConnectionError, ValueError) as err:
-            self._reset_orphan_miss_streaks()
             self._prepare_session_for_retry(err)
             if self._is_auth_error(err):
                 self._schedule_reauth()
                 raise UpdateFailed(f"Error fetching VPN data: {err}") from err
+            self._arm_recovery()
             raise UpdateFailed(
                 f"Error fetching VPN data: {err}",
                 retry_after=RETRY_AFTER_SECONDS,
             ) from err
         except TimeoutError as err:
-            self._reset_orphan_miss_streaks()
+            self._arm_recovery()
             self._prepare_session_for_retry(err)
             raise UpdateFailed(
                 f"Error fetching VPN data: {err}",
                 retry_after=RETRY_AFTER_SECONDS,
             ) from err
         except Exception as err:
-            self._reset_orphan_miss_streaks()
             self._prepare_session_for_retry(err)
             if self._is_auth_error(err):
                 self._schedule_reauth()
                 raise UpdateFailed(
                     f"Unexpected error fetching VPN data: {err}"
                 ) from err
+            self._arm_recovery()
             _LOGGER.exception("Unexpected error fetching VPN data")
             raise UpdateFailed(
                 f"Unexpected error fetching VPN data: {err}",
@@ -242,8 +422,9 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
 
     async def toggle_vpn(self, connection_uid: str, enable: bool) -> bool:
         """Toggle VPN on/off; schedule reauth on authentication errors."""
+        resolved = self.resolve_connection_uid(connection_uid)
         try:
-            return await self.fritz_session.async_toggle_vpn(connection_uid, enable)
+            return await self.fritz_session.async_toggle_vpn(resolved, enable)
         except Exception as err:
             if self._is_auth_error(err):
                 self._schedule_reauth()

--- a/custom_components/fritzbox_vpn/entity.py
+++ b/custom_components/fritzbox_vpn/entity.py
@@ -99,16 +99,20 @@ def connection_available(
     """True when the coordinator has data for this VPN connection."""
     if not coordinator.last_update_success or not coordinator.data:
         return False
-    return connection_uid in coordinator.data
+    resolved = coordinator.resolve_connection_uid(connection_uid)
+    return resolved in coordinator.data
 
 
 def connection_data(
     coordinator: FritzBoxVPNCoordinator, connection_uid: str
 ) -> dict[str, Any] | None:
     """VPN connection payload from coordinator data, if present."""
-    if not coordinator.data or connection_uid not in coordinator.data:
+    if not coordinator.data:
         return None
-    return coordinator.data[connection_uid]
+    resolved = coordinator.resolve_connection_uid(connection_uid)
+    if resolved not in coordinator.data:
+        return None
+    return coordinator.data[resolved]
 
 
 def vpn_switch_attributes(
@@ -118,13 +122,14 @@ def vpn_switch_attributes(
     conn = connection_data(coordinator, connection_uid)
     if conn is None:
         return {}
+    resolved = coordinator.resolve_connection_uid(connection_uid)
     return {
         API_KEY_NAME: conn.get(API_KEY_NAME),
-        ATTR_UID: connection_uid,
+        ATTR_UID: resolved,
         ATTR_VPN_UID: conn.get(API_KEY_UID),
         API_KEY_ACTIVE: conn.get(API_KEY_ACTIVE, False),
         API_KEY_CONNECTED: conn.get(API_KEY_CONNECTED, False),
-        ATTR_STATUS: coordinator.get_vpn_status(connection_uid),
+        ATTR_STATUS: coordinator.get_vpn_status(resolved),
     }
 
 

--- a/custom_components/fritzbox_vpn/entity_registry.py
+++ b/custom_components/fritzbox_vpn/entity_registry.py
@@ -349,7 +349,9 @@ def remap_connection_uids(
                 new_unique_id,
             )
             continue
-        entity_registry.async_update_entity(entry.entity_id, new_unique_id=new_unique_id)
+        entity_registry.async_update_entity(
+            entry.entity_id, new_unique_id=new_unique_id
+        )
         remapped_entities += 1
 
     for old_uid, new_uid in old_to_new.items():

--- a/custom_components/fritzbox_vpn/entity_registry.py
+++ b/custom_components/fritzbox_vpn/entity_registry.py
@@ -12,6 +12,7 @@ from homeassistant.util import slugify
 
 from .const import (
     DOMAIN,
+    LOG_MSG_ORPHAN_BASE_MERGE,
     UNIQUE_ID_PREFIX,
     UNIQUE_ID_SUFFIX_SWITCH,
     UNIQUE_ID_SUFFIXES,
@@ -21,6 +22,11 @@ from .models import runtime_from_hass
 _LOGGER = logging.getLogger(__name__)
 
 _ENTITY_ID_OBJECT_ID_SUFFIX_RE = re.compile(r"^(.+)_(\d+)$")
+
+
+def _entity_unique_id(connection_uid: str, suffix: str) -> str:
+    """Build entity unique_id (SSOT format; avoids importing entity.py)."""
+    return f"{UNIQUE_ID_PREFIX}{connection_uid}_{suffix}"
 
 
 def unique_id_suffix_from_entity_unique_id(unique_id: str) -> str | None:
@@ -305,10 +311,187 @@ def repair_entity_id_suffixes(
 
 
 def repair_entity_ids(hass: HomeAssistant, entry_id: str) -> tuple[int, list[str]]:
-    """Repair legacy object_id suffixes and numeric entity_id suffixes (_2, _3, ...)."""
+    """Repair legacy IDs, orphan-base+_2 merges, and free-base numeric suffixes."""
     legacy_count, legacy_messages = repair_legacy_entity_object_ids(hass, entry_id)
+    merge_count, merge_messages = repair_orphan_base_suffix_merges(hass, entry_id)
     suffix_count, suffix_messages = repair_entity_id_suffixes(hass, entry_id)
-    return (legacy_count + suffix_count, legacy_messages + suffix_messages)
+    return (
+        legacy_count + merge_count + suffix_count,
+        legacy_messages + merge_messages + suffix_messages,
+    )
+
+
+def remap_connection_uids(
+    hass: HomeAssistant,
+    entry_id: str,
+    old_to_new: dict[str, str],
+) -> int:
+    """Remap entity unique_ids and device identifiers; update runtime known_uids."""
+    if not old_to_new:
+        return 0
+
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    remapped_entities = 0
+
+    for entry in list(er.async_entries_for_config_entry(entity_registry, entry_id)):
+        unique_id = entry.unique_id or ""
+        old_uid = connection_uid_from_entity_unique_id(unique_id)
+        suffix = unique_id_suffix_from_entity_unique_id(unique_id)
+        if old_uid is None or suffix is None or old_uid not in old_to_new:
+            continue
+        new_uid = old_to_new[old_uid]
+        new_unique_id = _entity_unique_id(new_uid, suffix)
+        if entity_registry.async_get_entity_id(entry.domain, DOMAIN, new_unique_id):
+            _LOGGER.error(
+                "Cannot remap unique_id %s → %s; target already exists",
+                unique_id,
+                new_unique_id,
+            )
+            continue
+        entity_registry.async_update_entity(entry.entity_id, new_unique_id=new_unique_id)
+        remapped_entities += 1
+
+    for old_uid, new_uid in old_to_new.items():
+        device = device_registry.async_get_device(
+            identifiers={(DOMAIN, entry_id, old_uid)}
+        )
+        if device is None:
+            continue
+        existing_new = device_registry.async_get_device(
+            identifiers={(DOMAIN, entry_id, new_uid)}
+        )
+        if existing_new is not None and existing_new.id != device.id:
+            _LOGGER.error(
+                "Cannot remap device UID %s → %s; target device already exists",
+                old_uid,
+                new_uid,
+            )
+            continue
+        new_identifiers = set(device.identifiers)
+        new_identifiers.discard((DOMAIN, entry_id, old_uid))
+        new_identifiers.add((DOMAIN, entry_id, new_uid))
+        device_registry.async_update_device(device.id, new_identifiers=new_identifiers)
+
+    runtime = runtime_from_hass(hass, entry_id)
+    if runtime is not None:
+        runtime.remap_known_uids(old_to_new)
+
+    return remapped_entities
+
+
+def get_orphan_base_suffix_merges(
+    hass: HomeAssistant,
+    entry_id: str,
+    current_uids: set[str] | None = None,
+) -> list[tuple[er.RegistryEntry, er.RegistryEntry, str]]:
+    """Orphan base + live ``_2`` pairs eligible for merge.
+
+    Base unique_id UID must be absent from ``current_uids``; suffixed entry UID
+    must be present. Narrower than ``allow_replace_base=True``.
+    """
+    if current_uids is None:
+        current_uids, error_key = resolve_current_uids(hass, entry_id)
+        if error_key is not None or current_uids is None:
+            return []
+
+    registry = er.async_get(hass)
+    all_entries = er.async_entries_for_config_entry(registry, entry_id)
+    by_entity_id = {e.entity_id: e for e in all_entries}
+    result: list[tuple[er.RegistryEntry, er.RegistryEntry, str]] = []
+
+    for entry in all_entries:
+        base_entity_id = entity_id_base(entry.entity_id)
+        if not base_entity_id:
+            continue
+        base_entry = by_entity_id.get(base_entity_id)
+        if base_entry is None or base_entry.config_entry_id != entry_id:
+            continue
+        base_uid = connection_uid_from_entity_unique_id(base_entry.unique_id or "")
+        live_uid = connection_uid_from_entity_unique_id(entry.unique_id or "")
+        if base_uid is None or live_uid is None:
+            continue
+        if base_uid in current_uids:
+            continue
+        if live_uid not in current_uids:
+            continue
+        if base_uid == live_uid:
+            continue
+        result.append((base_entry, entry, base_entity_id))
+
+    # Prefer lowest numeric suffix per base when multiple exist.
+    preferred: dict[str, tuple[er.RegistryEntry, er.RegistryEntry, str]] = {}
+    for base_entry, suffixed_entry, base_entity_id in result:
+        existing = preferred.get(base_entity_id)
+        if existing is None:
+            preferred[base_entity_id] = (base_entry, suffixed_entry, base_entity_id)
+            continue
+        _, prev_suffixed, _ = existing
+        prev_n = entity_id_suffix_number(prev_suffixed.entity_id) or 10_000
+        cur_n = entity_id_suffix_number(suffixed_entry.entity_id) or 10_000
+        if cur_n < prev_n:
+            preferred[base_entity_id] = (base_entry, suffixed_entry, base_entity_id)
+    return list(preferred.values())
+
+
+def repair_orphan_base_suffix_merges(
+    hass: HomeAssistant,
+    entry_id: str,
+    current_uids: set[str] | None = None,
+) -> tuple[int, list[str]]:
+    """Remove orphan base registry rows and rename live ``_2`` entities to base IDs."""
+    merges = get_orphan_base_suffix_merges(hass, entry_id, current_uids)
+    if not merges:
+        return (0, [])
+
+    registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    messages: list[str] = []
+    orphan_uids: set[str] = set()
+    for base_entry, suffixed_entry, base_entity_id in merges:
+        try:
+            orphan_unique_id = base_entry.unique_id
+            orphan_uid = connection_uid_from_entity_unique_id(orphan_unique_id or "")
+            if orphan_uid is not None:
+                orphan_uids.add(orphan_uid)
+            registry.async_remove(base_entry.entity_id)
+            registry.async_update_entity(
+                suffixed_entry.entity_id, new_entity_id=base_entity_id
+            )
+            messages.append(f"{suffixed_entry.entity_id} → {base_entity_id}")
+            _LOGGER.warning(
+                LOG_MSG_ORPHAN_BASE_MERGE,
+                suffixed_entry.entity_id,
+                base_entity_id,
+                orphan_unique_id,
+            )
+        except Exception as err:
+            _LOGGER.warning(
+                "Failed orphan-base merge %s → %s: %s",
+                suffixed_entry.entity_id,
+                base_entity_id,
+                err,
+            )
+
+    for uid in orphan_uids:
+        device = device_registry.async_get_device(identifiers={(DOMAIN, entry_id, uid)})
+        if device is None:
+            continue
+        if er.async_entries_for_device(registry, device.id):
+            continue
+        device_registry.async_remove_device(device.id)
+        _LOGGER.info("Removed empty device after orphan-base merge for UID %s", uid)
+
+    return (len(messages), messages)
+
+
+def count_repairable_entity_issues(hass: HomeAssistant, entry_id: str) -> int:
+    """Pending legacy, orphan-base merge, and free-base suffix repairs."""
+    registry = er.async_get(hass)
+    legacy = get_legacy_entity_object_id_repairs(hass, entry_id)
+    merges = get_orphan_base_suffix_merges(hass, entry_id)
+    suffixes = get_entity_id_suffix_repairs(registry, entry_id)
+    return len(legacy) + len(merges) + len(suffixes)
 
 
 def remove_orphaned_entities(

--- a/custom_components/fritzbox_vpn/fritzconnection_session.py
+++ b/custom_components/fritzbox_vpn/fritzconnection_session.py
@@ -203,9 +203,7 @@ class FritzConnectionVPNSession:
                     raise TimeoutError(str(retry_err)) from retry_err
                 except RequestsConnectionError as retry_err:
                     self.invalidate_session()
-                    raise ConnectionError(
-                        f"{fail_message}: {retry_err}"
-                    ) from retry_err
+                    raise ConnectionError(f"{fail_message}: {retry_err}") from retry_err
                 except Exception as retry_err:
                     if self._is_fritz_authorization_error(retry_err):
                         self._raise_auth_error(

--- a/custom_components/fritzbox_vpn/fritzconnection_session.py
+++ b/custom_components/fritzbox_vpn/fritzconnection_session.py
@@ -3,17 +3,22 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from fritzboxvpn.const import DEFAULT_TIMEOUT
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import Timeout as RequestsTimeout
+
+from .const import LOG_MSG_SESSION_MODE_FALLBACK
 
 _LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:  # pragma: no cover
     from fritzconnection import FritzConnection
     from fritzconnection.lib.fritzwireguard import FritzWireguard
+
+T = TypeVar("T")
 
 
 class FritzConnectionVPNSession:
@@ -42,6 +47,7 @@ class FritzConnectionVPNSession:
         self._use_tls = use_tls
 
         self._mode: str | None = None
+        self._fallback_mode_logged = False
 
         self._fc: FritzConnection | None = None  # type: ignore[name-defined]
         self._fwg: FritzWireguard | None = None  # type: ignore[name-defined]
@@ -81,6 +87,9 @@ class FritzConnectionVPNSession:
                 protocol=protocol,
             )
             self._mode = "fritzboxvpn"
+            if not self._fallback_mode_logged:
+                self._fallback_mode_logged = True
+                _LOGGER.warning(LOG_MSG_SESSION_MODE_FALLBACK, self._host)
             return
 
         # Router API discovery happens here — callers must invoke this from a
@@ -154,17 +163,27 @@ class FritzConnectionVPNSession:
         if self._fc is not None:
             await self._hass.async_add_executor_job(self._close_sync)
 
-    async def async_get_vpn_connections(self) -> dict[str, Any]:
-        """Fetch latest VPN connections with HTTPS->HTTP fallback."""
+    def _raise_auth_error(self, err: Exception, *, as_value_error: bool) -> None:
+        """Raise auth failure with the caller-specific exception type."""
+        message = f"Login failed: {err}"
+        if as_value_error:
+            raise ValueError(message) from err
+        raise ConnectionError(message) from err
+
+    async def _async_with_https_http_fallback(
+        self,
+        *,
+        fallback_primary: Callable[[], Awaitable[T]],
+        sync_call: Callable[[], T],
+        fail_message: str,
+        auth_as_value_error: bool,
+    ) -> T:
+        """Run call; on HTTPS connect error retry once over HTTP."""
         try:
-            # Bootstrap (FritzConnection discovery) is inside the guarded path.
             await self._hass.async_add_executor_job(self._ensure_client)
             if self._mode == "fritzboxvpn":
-                assert self._fallback_session is not None
-                return await self._fallback_session.async_get_vpn_connections()
-            return await self._hass.async_add_executor_job(
-                self._get_vpn_connections_sync
-            )
+                return await fallback_primary()
+            return await self._hass.async_add_executor_job(sync_call)
         except RequestsTimeout as err:
             self.invalidate_session()
             raise TimeoutError(str(err)) from err
@@ -177,48 +196,53 @@ class FritzConnectionVPNSession:
                 )
                 self._use_tls = False
                 await self._hass.async_add_executor_job(self._close_sync)
-                return await self._hass.async_add_executor_job(
-                    self._get_vpn_connections_sync
-                )
+                try:
+                    return await self._hass.async_add_executor_job(sync_call)
+                except RequestsTimeout as retry_err:
+                    self.invalidate_session()
+                    raise TimeoutError(str(retry_err)) from retry_err
+                except RequestsConnectionError as retry_err:
+                    self.invalidate_session()
+                    raise ConnectionError(
+                        f"{fail_message}: {retry_err}"
+                    ) from retry_err
+                except Exception as retry_err:
+                    if self._is_fritz_authorization_error(retry_err):
+                        self._raise_auth_error(
+                            retry_err, as_value_error=auth_as_value_error
+                        )
+                    raise
             self.invalidate_session()
-            raise ConnectionError(f"failed to get login page: {err}") from err
+            raise ConnectionError(f"{fail_message}: {err}") from err
         except Exception as err:
             if self._is_fritz_authorization_error(err):
-                # Real credential failure (not Web-UI SID expiry).
-                raise ValueError(f"Login failed: {err}") from err
+                self._raise_auth_error(err, as_value_error=auth_as_value_error)
             raise
+
+    async def async_get_vpn_connections(self) -> dict[str, Any]:
+        """Fetch latest VPN connections with HTTPS->HTTP fallback."""
+
+        async def _fallback_primary() -> dict[str, Any]:
+            assert self._fallback_session is not None
+            return await self._fallback_session.async_get_vpn_connections()
+
+        return await self._async_with_https_http_fallback(
+            fallback_primary=_fallback_primary,
+            sync_call=self._get_vpn_connections_sync,
+            fail_message="failed to get login page",
+            auth_as_value_error=True,
+        )
 
     async def async_toggle_vpn(self, connection_uid: str, enable: bool) -> bool:
         """Toggle VPN on/off with HTTPS->HTTP fallback and auth propagation."""
-        try:
-            await self._hass.async_add_executor_job(self._ensure_client)
-            if self._mode == "fritzboxvpn":
-                assert self._fallback_session is not None
-                return await self._fallback_session.async_toggle_vpn(
-                    connection_uid, enable
-                )
-            return await self._hass.async_add_executor_job(
-                self._toggle_vpn_sync, connection_uid, enable
-            )
-        except RequestsTimeout as err:
-            self.invalidate_session()
-            raise TimeoutError(str(err)) from err
-        except RequestsConnectionError as err:
-            if self._use_tls:
-                _LOGGER.warning(
-                    "HTTPS connection failed; falling back to HTTP for host %s: %s",
-                    self._host,
-                    err,
-                )
-                self._use_tls = False
-                await self._hass.async_add_executor_job(self._close_sync)
-                return await self._hass.async_add_executor_job(
-                    self._toggle_vpn_sync, connection_uid, enable
-                )
-            self.invalidate_session()
-            raise ConnectionError(f"failed to toggle VPN: {err}") from err
-        except Exception as err:
-            if self._is_fritz_authorization_error(err):
-                # Real credential failure (not Web-UI SID expiry).
-                raise ConnectionError(f"Login failed: {err}") from err
-            raise
+
+        async def _fallback_primary() -> bool:
+            assert self._fallback_session is not None
+            return await self._fallback_session.async_toggle_vpn(connection_uid, enable)
+
+        return await self._async_with_https_http_fallback(
+            fallback_primary=_fallback_primary,
+            sync_call=lambda: self._toggle_vpn_sync(connection_uid, enable),
+            fail_message="failed to toggle VPN",
+            auth_as_value_error=False,
+        )

--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -16,5 +16,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.4b3"
+  "version": "1.2.4b4"
 }

--- a/custom_components/fritzbox_vpn/models.py
+++ b/custom_components/fritzbox_vpn/models.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from typing import Literal, TypeAlias
+from typing import TYPE_CHECKING, Literal, TypeAlias
 
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
 
-from .coordinator import FritzBoxVPNCoordinator
+if TYPE_CHECKING:
+    from .coordinator import FritzBoxVPNCoordinator
 
 RuntimePlatform = Literal["switch", "sensor", "binary_sensor"]
 
@@ -43,6 +44,20 @@ class FritzboxVpnRuntimeData:
         self.known_uids_switch -= uids
         self.known_uids_sensor -= uids
         self.known_uids_binary_sensor -= uids
+
+    def remap_known_uids(self, old_to_new: dict[str, str]) -> None:
+        """Replace tracked UIDs in existing set objects (platform closures keep refs)."""
+        if not old_to_new:
+            return
+        for known in (
+            self.known_uids_switch,
+            self.known_uids_sensor,
+            self.known_uids_binary_sensor,
+        ):
+            for old_uid, new_uid in old_to_new.items():
+                if old_uid in known:
+                    known.discard(old_uid)
+                    known.add(new_uid)
 
 
 FritzboxVpnConfigEntry: TypeAlias = ConfigEntry[FritzboxVpnRuntimeData | None]

--- a/custom_components/fritzbox_vpn/uid_identity.py
+++ b/custom_components/fritzbox_vpn/uid_identity.py
@@ -1,0 +1,50 @@
+"""Stable VPN connection UID identity helpers (name bijection remap)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fritzboxvpn import API_KEY_NAME
+
+
+def name_bijection_uid_remap(
+    old_uids: set[str],
+    new_uids: set[str],
+    old_names: dict[str, str],
+    new_payloads: dict[str, Any],
+) -> tuple[dict[str, str] | None, str | None]:
+    """Map old→new UIDs when names form a 1:1 bijection.
+
+    Returns ``(mapping, None)`` on success, or ``(None, reason)`` when remap
+    must be refused (no silent guessing).
+    """
+    if not old_uids or not new_uids or old_uids & new_uids:
+        return (None, "sets_overlap_or_empty")
+
+    old_by_name: dict[str, str] = {}
+    for uid in old_uids:
+        name = old_names.get(uid)
+        if name is None or not str(name).strip():
+            return (None, "missing_old_name")
+        name = str(name).strip()
+        if name in old_by_name:
+            return (None, "duplicate_old_name")
+        old_by_name[name] = uid
+
+    new_by_name: dict[str, str] = {}
+    for uid in new_uids:
+        payload = new_payloads.get(uid)
+        if not isinstance(payload, dict):
+            return (None, "missing_new_name")
+        name = payload.get(API_KEY_NAME)
+        if name is None or not str(name).strip():
+            return (None, "missing_new_name")
+        name = str(name).strip()
+        if name in new_by_name:
+            return (None, "duplicate_new_name")
+        new_by_name[name] = uid
+
+    if set(old_by_name) != set(new_by_name):
+        return (None, "name_sets_differ")
+
+    return ({old_by_name[name]: new_by_name[name] for name in old_by_name}, None)

--- a/docs/releases/v1.2.4b4.md
+++ b/docs/releases/v1.2.4b4.md
@@ -1,0 +1,15 @@
+## What's changed
+
+- **Fix (#37 residual):** After a Fritz!Box reboot, an empty VPN list during recovery is treated as an outage (not as all connections removed). Orphan confirmation is paused until recovery completes.
+- **Fix (#37 residual):** Name-stable VPN UID changes after outage are remapped in the entity/device registry — no new devices or `_2` entity IDs.
+- **Fix:** Orphan base entity + live `_2` pairs are merged on setup and via Options/Service repair.
+- **Hardening:** Clearer recovery/UID-delta/remap logs; FritzConnection adapter maps HTTPS+HTTP failure to `ConnectionError` and logs web-API fallback mode.
+
+### 🇩🇪 Deutsch
+
+- **Fix (#37 Residual):** Nach Fritz!Box-Reboot gilt eine leere VPN-Liste während der Recovery als Outage (nicht als Entfernung aller Verbindungen). Orphan-Bestätigung bleibt bis Recovery-Ende pausiert.
+- **Fix (#37 Residual):** Namensgleiche UID-Wechsel nach Outage werden in Entity-/Device-Registry remappt — keine neuen Devices/`_2`-Entity-IDs.
+- **Fix:** Orphan-Base + live-`_2`-Paare werden beim Setup und über Options/Service Repair gemerged.
+- **Härten:** Klarere Recovery-/UID-Delta-/Remap-Logs; Adapter mappt HTTPS+HTTP-Fail auf `ConnectionError` und loggt web-API-Fallback.
+
+**Full Changelog:** https://github.com/rosch100/fritzbox-vpn/compare/v1.2.4b3...v1.2.4b4

--- a/tests/test_config_flow_options.py
+++ b/tests/test_config_flow_options.py
@@ -11,8 +11,10 @@ from custom_components.fritzbox_vpn.const import (
     OPTIONS_ACTION_REPAIR_ENTITY_IDS,
     UNIQUE_ID_PREFIX,
 )
+from custom_components.fritzbox_vpn.coordinator import FritzBoxVPNCoordinator
 from custom_components.fritzbox_vpn.flow_forms import CannotConnect
-from homeassistant.config_entries import SOURCE_USER
+from custom_components.fritzbox_vpn.models import FritzboxVpnRuntimeData
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -193,6 +195,63 @@ async def test_options_repair_entity_ids_confirm(hass: HomeAssistant) -> None:
         )
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
+@pytest.mark.asyncio
+async def test_options_shows_repair_for_orphan_base_merge_only(
+    hass: HomeAssistant,
+) -> None:
+    """Repair action appears when only orphan-base+_2 merges are pending."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: MOCK_HOST,
+            CONF_USERNAME: MOCK_USERNAME,
+            CONF_PASSWORD: MOCK_PASSWORD,
+        },
+    )
+    entry.add_to_hass(hass)
+    entry.mock_state(hass, ConfigEntryState.LOADED)
+    coordinator = FritzBoxVPNCoordinator(hass, entry.data, None, entry.entry_id)
+    coordinator.fritz_session.async_close = AsyncMock()
+    coordinator.async_set_updated_data(
+        {
+            "vpn_new": {
+                "uid": "vpn_new",
+                "name": "Office VPN",
+                "active": True,
+                "connected": False,
+            }
+        }
+    )
+    entry.runtime_data = FritzboxVpnRuntimeData(coordinator=coordinator)
+
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}vpn_old_switch",
+        suggested_object_id="office_vpn",
+        config_entry=entry,
+    )
+    registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}vpn_new_switch",
+        suggested_object_id="office_vpn_2",
+        config_entry=entry,
+    )
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {"action": OPTIONS_ACTION_REPAIR_ENTITY_IDS},
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "repair_entity_ids_confirm"
 
 
 @pytest.mark.asyncio

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -27,6 +27,7 @@ def _mock_coordinator() -> MagicMock:
     coordinator.get_vpn_status = MagicMock(return_value=STATUS_ENABLED)
     coordinator.toggle_vpn = AsyncMock(return_value=True)
     coordinator.async_request_refresh = AsyncMock()
+    coordinator.resolve_connection_uid = lambda uid: uid
     return coordinator
 
 

--- a/tests/test_entities_extended.py
+++ b/tests/test_entities_extended.py
@@ -25,6 +25,7 @@ def _coordinator(**overrides):
     )
     coordinator.toggle_vpn = AsyncMock(return_value=overrides.get("toggle_ok", True))
     coordinator.async_request_refresh = AsyncMock()
+    coordinator.resolve_connection_uid = lambda uid: uid
     return coordinator
 
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -24,6 +24,7 @@ def test_connection_available_and_data() -> None:
     coordinator = MagicMock()
     coordinator.last_update_success = True
     coordinator.data = MOCK_VPN_CONNECTIONS
+    coordinator.resolve_connection_uid = lambda uid: uid
     assert connection_available(coordinator, "conn-abc") is True
     assert connection_data(coordinator, "missing") is None
 
@@ -33,6 +34,7 @@ def test_vpn_switch_attributes() -> None:
     coordinator = MagicMock()
     coordinator.data = MOCK_VPN_CONNECTIONS
     coordinator.get_vpn_status = MagicMock(return_value="enabled")
+    coordinator.resolve_connection_uid = lambda uid: uid
     attrs = vpn_switch_attributes(coordinator, "conn-abc")
     assert attrs["name"] == "Office VPN"
     assert attrs["status"] == "enabled"

--- a/tests/test_entity_lifecycle_reboot.py
+++ b/tests/test_entity_lifecycle_reboot.py
@@ -288,10 +288,18 @@ async def test_coordinator_update_failed_resets_orphan_miss_streak(
     with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()
     assert coordinator._missing_uid_counts == {}
+    assert coordinator._in_recovery()
 
+    # After outage, orphan confirmation stays paused until recovery clears.
     coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
         return_value={"conn-abc": MOCK_VPN_CONNECTIONS["conn-abc"]}
     )
+    for _ in range(ORPHAN_CONFIRM_POLLS):
+        await coordinator._async_update_data()
+    callback.assert_not_called()
+
+    coordinator._recovering_until = None
+    coordinator._recovery_stable_polls = 0
     for _ in range(ORPHAN_CONFIRM_POLLS - 1):
         await coordinator._async_update_data()
     callback.assert_not_called()

--- a/tests/test_fritzconnection_session.py
+++ b/tests/test_fritzconnection_session.py
@@ -119,3 +119,30 @@ async def test_get_vpn_connections_https_fallback_on_bootstrap_connection_error(
     assert data == {"a": {"uid": "a"}}
     assert session._use_tls is False
     assert calls["ensure"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_get_vpn_connections_https_and_http_fail_raises_connection_error() -> (
+    None
+):
+    """When HTTPS and HTTP both fail, raise ConnectionError (not raw requests)."""
+    hass = MagicMock()
+    session = FritzConnectionVPNSession(hass, "1.2.3.4", "u", "p", use_tls=True)
+
+    def ensure() -> None:
+        raise RequestsConnectionError("down")
+
+    session._ensure_client = ensure  # type: ignore[method-assign]
+    session._close_sync = MagicMock()  # type: ignore[method-assign]
+    session._get_vpn_connections_sync = MagicMock(  # type: ignore[method-assign]
+        side_effect=RequestsConnectionError("http down")
+    )
+
+    async def run_job(fn, *args):
+        return fn(*args)
+
+    hass.async_add_executor_job = AsyncMock(side_effect=run_job)
+
+    with pytest.raises(ConnectionError, match="failed to get login page"):
+        await session.async_get_vpn_connections()
+    assert session._use_tls is True

--- a/tests/test_reboot_recovery_entity_churn.py
+++ b/tests/test_reboot_recovery_entity_churn.py
@@ -1,0 +1,479 @@
+"""Regression tests for #37 reboot empty-list / UID-churn / orphan-base+_2 heal."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from custom_components.fritzbox_vpn import _repair_entity_ids_before_platform_setup
+from custom_components.fritzbox_vpn.const import (
+    DOMAIN,
+    ORPHAN_CONFIRM_POLLS,
+    RECOVERY_STABLE_POLLS,
+    UNIQUE_ID_PREFIX,
+    UNIQUE_ID_SUFFIX_SWITCH,
+)
+from custom_components.fritzbox_vpn.coordinator import FritzBoxVPNCoordinator
+from custom_components.fritzbox_vpn.entity import (
+    connection_available,
+    setup_vpn_platform,
+    vpn_unique_id,
+)
+from custom_components.fritzbox_vpn.entity_registry import (
+    count_repairable_entity_issues,
+    get_orphan_base_suffix_merges,
+    remap_connection_uids,
+    repair_orphan_base_suffix_merges,
+)
+from custom_components.fritzbox_vpn.models import FritzboxVpnRuntimeData
+from custom_components.fritzbox_vpn.uid_identity import name_bijection_uid_remap
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from tests.fixtures import MOCK_HOST, MOCK_VPN_CONNECTIONS
+
+
+def _coordinator(hass: HomeAssistant, entry: MockConfigEntry) -> FritzBoxVPNCoordinator:
+    coordinator = FritzBoxVPNCoordinator(
+        hass, entry.data, None, entry.entry_id, on_orphaned_removed=MagicMock()
+    )
+    coordinator.fritz_session = MagicMock()
+    coordinator.fritz_session.invalidate_session = MagicMock()
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_empty_list_during_recovery_is_outage_not_orphan(
+    hass: HomeAssistant,
+) -> None:
+    """Empty {} after connect failure must not confirm orphans or replace data."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": MOCK_HOST, "username": "u", "password": "p"},
+    )
+    entry.add_to_hass(hass)
+    coordinator = _coordinator(hass, entry)
+    coordinator.async_set_updated_data(dict(MOCK_VPN_CONNECTIONS))
+    coordinator._seen_uids = set(MOCK_VPN_CONNECTIONS)
+    coordinator._remember_connection_names(MOCK_VPN_CONNECTIONS)
+
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        side_effect=ConnectionError("refused")
+    )
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+    assert coordinator._in_recovery()
+
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(return_value={})
+    for _ in range(ORPHAN_CONFIRM_POLLS + 1):
+        with pytest.raises(UpdateFailed, match="empty while recovering"):
+            await coordinator._async_update_data()
+
+    coordinator._on_orphaned_removed.assert_not_called()
+    assert coordinator.data == MOCK_VPN_CONNECTIONS
+
+
+@pytest.mark.asyncio
+async def test_partial_during_recovery_does_not_confirm_orphan(
+    hass: HomeAssistant,
+) -> None:
+    """Partial lists during recovery must not fire orphan confirmation."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": MOCK_HOST, "username": "u", "password": "p"},
+    )
+    callback = MagicMock()
+    coordinator = FritzBoxVPNCoordinator(
+        hass, entry.data, None, entry.entry_id, on_orphaned_removed=callback
+    )
+    coordinator.async_set_updated_data(dict(MOCK_VPN_CONNECTIONS))
+    coordinator.fritz_session = MagicMock()
+    coordinator.fritz_session.invalidate_session = MagicMock()
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        side_effect=ConnectionError("refused")
+    )
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        return_value={"conn-abc": MOCK_VPN_CONNECTIONS["conn-abc"]}
+    )
+    for _ in range(ORPHAN_CONFIRM_POLLS + 2):
+        await coordinator._async_update_data()
+    callback.assert_not_called()
+
+
+def test_name_bijection_uid_remap_success_and_refuse() -> None:
+    """Bijection requires unique matching names; duplicates refuse remap."""
+    mapping, reason = name_bijection_uid_remap(
+        {"old-a", "old-b"},
+        {"new-a", "new-b"},
+        {"old-a": "Office VPN", "old-b": "Guest VPN"},
+        {
+            "new-a": {"name": "Office VPN"},
+            "new-b": {"name": "Guest VPN"},
+        },
+    )
+    assert reason is None
+    assert mapping == {"old-a": "new-a", "old-b": "new-b"}
+
+    mapping, reason = name_bijection_uid_remap(
+        {"old-a", "old-b"},
+        {"new-a", "new-b"},
+        {"old-a": "Same", "old-b": "Same"},
+        {
+            "new-a": {"name": "Same"},
+            "new-b": {"name": "Other"},
+        },
+    )
+    assert mapping is None
+    assert reason == "duplicate_old_name"
+
+
+@pytest.mark.asyncio
+async def test_recovery_uid_remap_updates_registry_and_alias(
+    hass: HomeAssistant,
+) -> None:
+    """Name-stable UID churn remaps registry and keeps old entity UID available."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": MOCK_HOST, "username": "u", "password": "p"},
+    )
+    entry.add_to_hass(hass)
+    entry.mock_state(hass, ConfigEntryState.LOADED)
+
+    coordinator = _coordinator(hass, entry)
+    old = {
+        "old-abc": {
+            "uid": "old-abc",
+            "name": "Office VPN",
+            "active": True,
+            "connected": False,
+        },
+        "old-def": {
+            "uid": "old-def",
+            "name": "Guest VPN",
+            "active": False,
+            "connected": False,
+        },
+    }
+    coordinator.async_set_updated_data(old)
+    coordinator._seen_uids = set(old)
+    coordinator._remember_connection_names(old)
+    entry.runtime_data = FritzboxVpnRuntimeData(coordinator=coordinator)
+    entry.runtime_data.known_uids_switch = set(old)
+
+    registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    for uid, payload in old.items():
+        registry.async_get_or_create(
+            "switch",
+            DOMAIN,
+            vpn_unique_id(uid, UNIQUE_ID_SUFFIX_SWITCH),
+            config_entry=entry,
+        )
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, entry.entry_id, uid)},
+            name=payload["name"],
+        )
+
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        side_effect=ConnectionError("refused")
+    )
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+    new = {
+        "new-abc": {
+            "uid": "new-abc",
+            "name": "Office VPN",
+            "active": True,
+            "connected": False,
+        },
+        "new-def": {
+            "uid": "new-def",
+            "name": "Guest VPN",
+            "active": False,
+            "connected": False,
+        },
+    }
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(return_value=new)
+    result = await coordinator._async_update_data()
+    assert set(result) == {"new-abc", "new-def"}
+    assert coordinator.resolve_connection_uid("old-abc") == "new-abc"
+    assert entry.runtime_data.known_uids_switch == {"new-abc", "new-def"}
+
+    assert registry.async_get_entity_id(
+        "switch", DOMAIN, vpn_unique_id("new-abc", UNIQUE_ID_SUFFIX_SWITCH)
+    )
+    assert (
+        registry.async_get_entity_id(
+            "switch", DOMAIN, vpn_unique_id("old-abc", UNIQUE_ID_SUFFIX_SWITCH)
+        )
+        is None
+    )
+    assert device_registry.async_get_device(
+        identifiers={(DOMAIN, entry.entry_id, "new-abc")}
+    )
+    assert (
+        device_registry.async_get_device(
+            identifiers={(DOMAIN, entry.entry_id, "old-abc")}
+        )
+        is None
+    )
+
+    coordinator.async_set_updated_data(new)
+    coordinator.last_update_success = True
+    assert connection_available(coordinator, "old-abc") is True
+
+
+@pytest.mark.asyncio
+async def test_uid_remap_prevents_platform_readd(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """After remapping known_uids, platforms must not async_add remapped UIDs."""
+    mock_config_entry.add_to_hass(hass)
+    mock_config_entry.mock_state(hass, ConfigEntryState.LOADED)
+    coordinator = FritzBoxVPNCoordinator(
+        hass, mock_config_entry.data, None, mock_config_entry.entry_id
+    )
+    old = {
+        "old-abc": {**MOCK_VPN_CONNECTIONS["conn-abc"], "uid": "old-abc", "name": "Office VPN"},
+    }
+    coordinator.async_set_updated_data(old)
+    coordinator.last_update_success = True
+    mock_config_entry.runtime_data = FritzboxVpnRuntimeData(coordinator=coordinator)
+
+    add_calls: list[list] = []
+
+    def _async_add_entities(entities, **kwargs):
+        add_calls.append(list(entities))
+
+    def _create_entities(coord, uids):
+        entities = []
+        for uid in uids:
+            entity = MagicMock()
+            entity.unique_id = vpn_unique_id(uid, UNIQUE_ID_SUFFIX_SWITCH)
+            entity._connection_uid = uid
+            entities.append(entity)
+        return entities
+
+    await setup_vpn_platform(
+        mock_config_entry,
+        _async_add_entities,
+        platform="switch",
+        create_entities=_create_entities,
+    )
+    assert len(add_calls) == 1
+
+    remap_connection_uids(hass, mock_config_entry.entry_id, {"old-abc": "new-abc"})
+    assert mock_config_entry.runtime_data.known_uids_switch == {"new-abc"}
+
+    coordinator.async_set_updated_data(
+        {
+            "new-abc": {
+                "uid": "new-abc",
+                "name": "Office VPN",
+                "active": True,
+                "connected": False,
+            }
+        }
+    )
+    await hass.async_block_till_done()
+    assert len(add_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_orphan_base_suffix_merge_and_setup_heal(hass: HomeAssistant) -> None:
+    """Orphan base + live _2 merges; live+live base+_2 stays untouched."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": MOCK_HOST})
+    entry.add_to_hass(hass)
+    entry.mock_state(hass, ConfigEntryState.LOADED)
+    coordinator = FritzBoxVPNCoordinator(
+        hass,
+        {"host": MOCK_HOST, "username": "u", "password": "p"},
+        None,
+        entry.entry_id,
+    )
+    coordinator.async_set_updated_data(
+        {
+            "vpn_new": {
+                "uid": "vpn_new",
+                "name": "Office VPN",
+                "active": True,
+                "connected": False,
+            }
+        }
+    )
+    entry.runtime_data = FritzboxVpnRuntimeData(coordinator=coordinator)
+
+    registry = er.async_get(hass)
+    base = registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}vpn_old_switch",
+        suggested_object_id="office_vpn",
+        config_entry=entry,
+    )
+    suffixed = registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}vpn_new_switch",
+        suggested_object_id="office_vpn_2",
+        config_entry=entry,
+    )
+    assert base.entity_id == "switch.office_vpn"
+    assert suffixed.entity_id == "switch.office_vpn_2"
+
+    merges = get_orphan_base_suffix_merges(hass, entry.entry_id)
+    assert len(merges) == 1
+    assert count_repairable_entity_issues(hass, entry.entry_id) >= 1
+
+    count, messages = repair_orphan_base_suffix_merges(hass, entry.entry_id)
+    assert count == 1
+    assert messages
+    assert registry.async_get("switch.office_vpn_2") is None
+    healed = registry.async_get("switch.office_vpn")
+    assert healed is not None
+    assert healed.unique_id == f"{UNIQUE_ID_PREFIX}vpn_new_switch"
+
+    # Live base + live _2 (same current UID set containing both) must not merge.
+    entry2 = MockConfigEntry(domain=DOMAIN, data={"host": MOCK_HOST})
+    entry2.add_to_hass(hass)
+    entry2.mock_state(hass, ConfigEntryState.LOADED)
+    coordinator2 = FritzBoxVPNCoordinator(
+        hass,
+        {"host": MOCK_HOST, "username": "u", "password": "p"},
+        None,
+        entry2.entry_id,
+    )
+    coordinator2.async_set_updated_data(
+        {
+            "vpn1": {"uid": "vpn1", "name": "A", "active": True, "connected": False},
+            "vpn1b": {"uid": "vpn1b", "name": "B", "active": True, "connected": False},
+        }
+    )
+    entry2.runtime_data = FritzboxVpnRuntimeData(coordinator=coordinator2)
+    registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}vpn1_connected",
+        suggested_object_id="office_vpn_connected",
+        config_entry=entry2,
+    )
+    registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{UNIQUE_ID_PREFIX}vpn1b_connected",
+        suggested_object_id="office_vpn_connected_2",
+        config_entry=entry2,
+    )
+    assert get_orphan_base_suffix_merges(hass, entry2.entry_id) == []
+    assert _repair_entity_ids_before_platform_setup(hass, entry2.entry_id) == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_recovery_then_same_uids_available_no_readd(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Outage → empty → same UIDs: no orphan callback and no entity re-add."""
+    mock_config_entry.add_to_hass(hass)
+    mock_config_entry.mock_state(hass, ConfigEntryState.LOADED)
+    callback = MagicMock()
+    coordinator = FritzBoxVPNCoordinator(
+        hass,
+        mock_config_entry.data,
+        None,
+        mock_config_entry.entry_id,
+        on_orphaned_removed=callback,
+    )
+    coordinator.async_set_updated_data(dict(MOCK_VPN_CONNECTIONS))
+    coordinator.last_update_success = True
+    coordinator.fritz_session = MagicMock()
+    coordinator.fritz_session.invalidate_session = MagicMock()
+    coordinator.fritz_session.async_close = AsyncMock()
+    mock_config_entry.runtime_data = FritzboxVpnRuntimeData(coordinator=coordinator)
+
+    add_calls: list[list] = []
+
+    def _async_add_entities(entities, **kwargs):
+        add_calls.append(list(entities))
+
+    def _create_entities(coord, uids):
+        return [
+            MagicMock(
+                unique_id=vpn_unique_id(uid, UNIQUE_ID_SUFFIX_SWITCH),
+                _connection_uid=uid,
+            )
+            for uid in uids
+        ]
+
+    await setup_vpn_platform(
+        mock_config_entry,
+        _async_add_entities,
+        platform="switch",
+        create_entities=_create_entities,
+    )
+    assert len(add_calls) == 1
+
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        side_effect=ConnectionError("refused")
+    )
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(return_value={})
+    with pytest.raises(UpdateFailed, match="empty while recovering"):
+        await coordinator._async_update_data()
+
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        return_value=dict(MOCK_VPN_CONNECTIONS)
+    )
+    data = await coordinator._async_update_data()
+    assert set(data) == set(MOCK_VPN_CONNECTIONS)
+    callback.assert_not_called()
+
+    coordinator.async_set_updated_data(dict(MOCK_VPN_CONNECTIONS))
+    coordinator.last_update_success = True
+    await hass.async_block_till_done()
+    assert len(add_calls) == 1
+    assert connection_available(coordinator, "conn-abc") is True
+
+
+@pytest.mark.asyncio
+async def test_recovery_clears_after_window_and_stable_polls(
+    hass: HomeAssistant,
+) -> None:
+    """Recovery exits only after min window elapsed and stable non-empty polls."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": MOCK_HOST, "username": "u", "password": "p"},
+    )
+    coordinator = _coordinator(hass, entry)
+    coordinator.async_set_updated_data(dict(MOCK_VPN_CONNECTIONS))
+    coordinator._seen_uids = set(MOCK_VPN_CONNECTIONS)
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        side_effect=ConnectionError("refused")
+    )
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+    assert coordinator._in_recovery()
+
+    # Time not elapsed yet: stable polls alone must not clear recovery.
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        return_value=dict(MOCK_VPN_CONNECTIONS)
+    )
+    for _ in range(RECOVERY_STABLE_POLLS + 1):
+        await coordinator._async_update_data()
+    assert coordinator._in_recovery()
+
+    coordinator._recovering_until = 0  # window.monotonic() always >= 0
+    coordinator._recovery_stable_polls = 0
+    for _ in range(RECOVERY_STABLE_POLLS):
+        await coordinator._async_update_data()
+    assert not coordinator._in_recovery()

--- a/tests/test_reboot_recovery_entity_churn.py
+++ b/tests/test_reboot_recovery_entity_churn.py
@@ -243,7 +243,11 @@ async def test_uid_remap_prevents_platform_readd(
         hass, mock_config_entry.data, None, mock_config_entry.entry_id
     )
     old = {
-        "old-abc": {**MOCK_VPN_CONNECTIONS["conn-abc"], "uid": "old-abc", "name": "Office VPN"},
+        "old-abc": {
+            **MOCK_VPN_CONNECTIONS["conn-abc"],
+            "uid": "old-abc",
+            "name": "Office VPN",
+        },
     }
     coordinator.async_set_updated_data(old)
     coordinator.last_update_success = True


### PR DESCRIPTION
## Summary
- Treat empty VPN lists during post-outage recovery as outages (no orphan spam / `_2` churn after Fritz!Box reboot).
- Remap name-stable UID changes in entity/device registry; merge orphan base + live `_2` pairs on setup/Options repair.
- Clearer recovery/UID-delta logs; adapter maps HTTPS+HTTP failure to `ConnectionError` (beta **v1.2.4b4**).

## Test plan
- [x] `ruff check` + `pytest` with coverage ≥ 85%
- [ ] After merge: tag `v1.2.4b4` and confirm GitHub pre-release
- [ ] ekr / reboot: entities recover without new `_2` suffixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recovery after Fritz!Box connectivity interruptions, preserving entities during temporary or incomplete responses.
  * Added safe connection identity remapping when VPN identifiers change.
  * Added automatic repair for orphaned and duplicate entity entries.
  * Improved HTTPS/HTTP fallback handling and diagnostics.

* **Bug Fixes**
  * Prevented premature removal of VPN connections during recovery.
  * Ensured connection controls continue working after identifier changes.

* **Documentation**
  * Added release notes for version 1.2.4b4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->