### PR TITLE
fix: CodeRabbit follow-up for reboot recovery (v1.2.4b5)

### DIFF
--- a/custom_components/fritzbox_vpn/const.py
+++ b/custom_components/fritzbox_vpn/const.py
@@ -27,6 +27,9 @@ ORPHAN_CONFIRM_POLLS = 3
 # before orphan tracking resumes (see issue #37 / reboot empty-list churn).
 RECOVERY_STABLE_POLLS = 2
 RECOVERY_MIN_INTERVAL_FACTOR = 3
+# Cap recovery so a permanently empty VPN list cannot block forever
+# (max = factor × minimum recovery window).
+RECOVERY_MAX_WINDOW_FACTOR = 2
 
 ATTR_UID = "uid"
 ATTR_VPN_UID = "vpn_uid"
@@ -70,6 +73,10 @@ LOG_MSG_RECOVERY_CLEARED = (
 LOG_MSG_EMPTY_DURING_RECOVERY = (
     "Empty VPN list from %s while recovering after outage "
     "(seen_uids=%d); treating as outage, not connection removal."
+)
+LOG_MSG_RECOVERY_EMPTY_ACCEPTED = (
+    "Empty VPN list from %s persisted past max recovery (%ss); "
+    "accepting empty result and clearing recovery (seen_uids=%d)."
 )
 LOG_MSG_UID_DELTA = "VPN UID delta on %s: added=%s removed=%s"
 LOG_MSG_UID_REMAP = (

--- a/custom_components/fritzbox_vpn/coordinator.py
+++ b/custom_components/fritzbox_vpn/coordinator.py
@@ -27,6 +27,7 @@ from .const import (
     LOG_MSG_EMPTY_DURING_RECOVERY,
     LOG_MSG_RECOVERY_ARMED,
     LOG_MSG_RECOVERY_CLEARED,
+    LOG_MSG_RECOVERY_EMPTY_ACCEPTED,
     LOG_MSG_UID_DELTA,
     LOG_MSG_UID_REMAP,
     LOG_MSG_UID_REMAP_REFUSED,
@@ -34,6 +35,7 @@ from .const import (
     LOG_MSG_VPN_CONNECTIONS_REMOVED_HINT,
     NAME_FRITZBOX,
     ORPHAN_CONFIRM_POLLS,
+    RECOVERY_MAX_WINDOW_FACTOR,
     RECOVERY_MIN_INTERVAL_FACTOR,
     RECOVERY_STABLE_POLLS,
     RETRY_AFTER_SECONDS,
@@ -104,6 +106,11 @@ def recovery_window_seconds(update_interval_seconds: int) -> int:
     )
 
 
+def recovery_max_seconds(update_interval_seconds: int) -> int:
+    """Hard cap so recovery cannot stick forever on a permanently empty list."""
+    return RECOVERY_MAX_WINDOW_FACTOR * recovery_window_seconds(update_interval_seconds)
+
+
 class FritzBoxVPNCoordinator(DataUpdateCoordinator):
     """Coordinator for FritzBox VPN data."""
 
@@ -141,6 +148,7 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
         self._uid_names: dict[str, str] = {}
         self._uid_remap: dict[str, str] = {}
         self._recovering_until: float | None = None
+        self._recovery_started_at: float | None = None
         self._recovery_stable_polls: int = 0
 
     def resolve_connection_uid(self, connection_uid: str) -> str:
@@ -218,6 +226,8 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
         duration = recovery_window_seconds(self._update_interval_seconds)
         until = time.monotonic() + duration
         was_recovering = self._recovering_until is not None
+        if self._recovery_started_at is None:
+            self._recovery_started_at = time.monotonic()
         if self._recovering_until is None or until > self._recovering_until:
             self._recovering_until = until
         self._recovery_stable_polls = 0
@@ -230,6 +240,21 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
                 len(self._seen_uids),
             )
 
+    def _clear_recovery(self) -> None:
+        """Exit recovery window and reset related counters."""
+        self._recovering_until = None
+        self._recovery_started_at = None
+        self._recovery_stable_polls = 0
+
+    def _recovery_max_elapsed(self) -> bool:
+        """True when recovery has exceeded the hard empty-list cap."""
+        if self._recovery_started_at is None:
+            return False
+        return time.monotonic() >= (
+            self._recovery_started_at
+            + recovery_max_seconds(self._update_interval_seconds)
+        )
+
     def _note_successful_poll(self, connections: dict[str, Any]) -> None:
         """Advance or clear recovery based on non-empty successful polls."""
         if self._recovering_until is None:
@@ -237,13 +262,13 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
         if not connections:
             self._recovery_stable_polls = 0
             return
-        self._recovery_stable_polls += 1
-        if (
-            time.monotonic() >= self._recovering_until
-            and self._recovery_stable_polls >= RECOVERY_STABLE_POLLS
-        ):
-            self._recovering_until = None
+        # Only count stable polls after the minimum recovery window elapses.
+        if time.monotonic() < self._recovering_until:
             self._recovery_stable_polls = 0
+            return
+        self._recovery_stable_polls += 1
+        if self._recovery_stable_polls >= RECOVERY_STABLE_POLLS:
+            self._clear_recovery()
             _LOGGER.info(
                 LOG_MSG_RECOVERY_CLEARED,
                 host_from_config(self.config),
@@ -293,8 +318,16 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
             )
             return
 
-        remapped = remap_connection_uids(self.hass, self.entry_id, mapping)
-        for old_uid, new_uid in mapping.items():
+        applied = remap_connection_uids(self.hass, self.entry_id, mapping)
+        skipped = set(mapping) - set(applied)
+        if skipped:
+            _LOGGER.error(
+                "UID remap partially skipped for %s; refused=%s applied=%s",
+                host,
+                sorted(skipped),
+                sorted(applied),
+            )
+        for old_uid, new_uid in applied.items():
             self._uid_remap[old_uid] = new_uid
             self._seen_uids.discard(old_uid)
             self._seen_uids.add(new_uid)
@@ -314,10 +347,10 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
                 new_uid,
                 self._uid_names.get(new_uid, new_uid),
             )
-        if remapped:
+        if applied:
             _LOGGER.info(
-                "Remapped %d entity unique_id(s) after outage recovery for entry %s",
-                remapped,
+                "Remapped %d connection UID(s) after outage recovery for entry %s",
+                len(applied),
                 self.entry_id,
             )
 
@@ -346,17 +379,28 @@ class FritzBoxVPNCoordinator(DataUpdateCoordinator):
             connections = await self.fritz_session.async_get_vpn_connections()
             had_connections = bool(self._seen_uids) or bool(self.data)
             if not connections and self._in_recovery() and had_connections:
-                _LOGGER.warning(
-                    LOG_MSG_EMPTY_DURING_RECOVERY,
-                    host_from_config(self.config),
-                    len(self._seen_uids) or len(self.data or {}),
-                )
-                self._reset_orphan_miss_streaks()
-                self._recovery_stable_polls = 0
-                raise UpdateFailed(
-                    "VPN list empty while recovering after connectivity outage",
-                    retry_after=RETRY_AFTER_SECONDS,
-                )
+                seen_count = len(self._seen_uids) or len(self.data or {})
+                if self._recovery_max_elapsed():
+                    max_seconds = recovery_max_seconds(self._update_interval_seconds)
+                    _LOGGER.warning(
+                        LOG_MSG_RECOVERY_EMPTY_ACCEPTED,
+                        host_from_config(self.config),
+                        max_seconds,
+                        seen_count,
+                    )
+                    self._clear_recovery()
+                else:
+                    _LOGGER.warning(
+                        LOG_MSG_EMPTY_DURING_RECOVERY,
+                        host_from_config(self.config),
+                        seen_count,
+                    )
+                    self._reset_orphan_miss_streaks()
+                    self._recovery_stable_polls = 0
+                    raise UpdateFailed(
+                        "VPN list empty while recovering after connectivity outage",
+                        retry_after=RETRY_AFTER_SECONDS,
+                    )
 
             current_uids = set(connections.keys())
             self._remember_connection_names(connections)

--- a/custom_components/fritzbox_vpn/entity.py
+++ b/custom_components/fritzbox_vpn/entity.py
@@ -20,10 +20,10 @@ from .const import (
     DOMAIN,
     MANUFACTURER_AVM,
     MODEL_WIREGUARD_VPN,
-    UNIQUE_ID_PREFIX,
 )
 from .coordinator import FritzBoxVPNCoordinator
 from .models import FritzboxVpnConfigEntry, RuntimePlatform, runtime_from_entry
+from .uid_identity import entity_unique_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -75,7 +75,7 @@ def vpn_entities_for_uids(
 
 def vpn_unique_id(connection_uid: str, suffix: str) -> str:
     """Entity unique_id for a VPN connection and platform suffix."""
-    return f"{UNIQUE_ID_PREFIX}{connection_uid}_{suffix}"
+    return entity_unique_id(connection_uid, suffix)
 
 
 def vpn_device_info(

--- a/custom_components/fritzbox_vpn/entity_registry.py
+++ b/custom_components/fritzbox_vpn/entity_registry.py
@@ -18,15 +18,11 @@ from .const import (
     UNIQUE_ID_SUFFIXES,
 )
 from .models import runtime_from_hass
+from .uid_identity import entity_unique_id
 
 _LOGGER = logging.getLogger(__name__)
 
 _ENTITY_ID_OBJECT_ID_SUFFIX_RE = re.compile(r"^(.+)_(\d+)$")
-
-
-def _entity_unique_id(connection_uid: str, suffix: str) -> str:
-    """Build entity unique_id (SSOT format; avoids importing entity.py)."""
-    return f"{UNIQUE_ID_PREFIX}{connection_uid}_{suffix}"
 
 
 def unique_id_suffix_from_entity_unique_id(unique_id: str) -> str | None:
@@ -325,14 +321,18 @@ def remap_connection_uids(
     hass: HomeAssistant,
     entry_id: str,
     old_to_new: dict[str, str],
-) -> int:
-    """Remap entity unique_ids and device identifiers; update runtime known_uids."""
+) -> dict[str, str]:
+    """Remap entity unique_ids and device identifiers; update runtime known_uids.
+
+    Returns the subset of ``old_to_new`` that was actually applied (entity and/or
+    device remap succeeded). Callers must only record applied pairs.
+    """
     if not old_to_new:
-        return 0
+        return {}
 
     entity_registry = er.async_get(hass)
     device_registry = dr.async_get(hass)
-    remapped_entities = 0
+    entity_remapped_uids: set[str] = set()
 
     for entry in list(er.async_entries_for_config_entry(entity_registry, entry_id)):
         unique_id = entry.unique_id or ""
@@ -341,7 +341,7 @@ def remap_connection_uids(
         if old_uid is None or suffix is None or old_uid not in old_to_new:
             continue
         new_uid = old_to_new[old_uid]
-        new_unique_id = _entity_unique_id(new_uid, suffix)
+        new_unique_id = entity_unique_id(new_uid, suffix)
         if entity_registry.async_get_entity_id(entry.domain, DOMAIN, new_unique_id):
             _LOGGER.error(
                 "Cannot remap unique_id %s → %s; target already exists",
@@ -352,8 +352,9 @@ def remap_connection_uids(
         entity_registry.async_update_entity(
             entry.entity_id, new_unique_id=new_unique_id
         )
-        remapped_entities += 1
+        entity_remapped_uids.add(old_uid)
 
+    device_remapped_uids: set[str] = set()
     for old_uid, new_uid in old_to_new.items():
         device = device_registry.async_get_device(
             identifiers={(DOMAIN, entry_id, old_uid)}
@@ -374,12 +375,18 @@ def remap_connection_uids(
         new_identifiers.discard((DOMAIN, entry_id, old_uid))
         new_identifiers.add((DOMAIN, entry_id, new_uid))
         device_registry.async_update_device(device.id, new_identifiers=new_identifiers)
+        device_remapped_uids.add(old_uid)
+
+    applied = {
+        old_uid: old_to_new[old_uid]
+        for old_uid in entity_remapped_uids | device_remapped_uids
+    }
 
     runtime = runtime_from_hass(hass, entry_id)
-    if runtime is not None:
-        runtime.remap_known_uids(old_to_new)
+    if runtime is not None and applied:
+        runtime.remap_known_uids(applied)
 
-    return remapped_entities
+    return applied
 
 
 def get_orphan_base_suffix_merges(

--- a/custom_components/fritzbox_vpn/entity_registry.py
+++ b/custom_components/fritzbox_vpn/entity_registry.py
@@ -324,15 +324,18 @@ def remap_connection_uids(
 ) -> dict[str, str]:
     """Remap entity unique_ids and device identifiers; update runtime known_uids.
 
-    Returns the subset of ``old_to_new`` that was actually applied (entity and/or
-    device remap succeeded). Callers must only record applied pairs.
+    Returns only UIDs for which every matching entity (all platforms) and the
+    device (when present) can remap without conflict. Partial successes are not
+    applied or returned.
     """
     if not old_to_new:
         return {}
 
     entity_registry = er.async_get(hass)
     device_registry = dr.async_get(hass)
-    entity_remapped_uids: set[str] = set()
+    planned_entities: dict[str, list[tuple[er.RegistryEntry, str]]] = {}
+    planned_devices: dict[str, dr.DeviceEntry] = {}
+    conflicted: set[str] = set()
 
     for entry in list(er.async_entries_for_config_entry(entity_registry, entry_id)):
         unique_id = entry.unique_id or ""
@@ -348,13 +351,10 @@ def remap_connection_uids(
                 unique_id,
                 new_unique_id,
             )
+            conflicted.add(old_uid)
             continue
-        entity_registry.async_update_entity(
-            entry.entity_id, new_unique_id=new_unique_id
-        )
-        entity_remapped_uids.add(old_uid)
+        planned_entities.setdefault(old_uid, []).append((entry, new_unique_id))
 
-    device_remapped_uids: set[str] = set()
     for old_uid, new_uid in old_to_new.items():
         device = device_registry.async_get_device(
             identifiers={(DOMAIN, entry_id, old_uid)}
@@ -370,17 +370,30 @@ def remap_connection_uids(
                 old_uid,
                 new_uid,
             )
+            conflicted.add(old_uid)
             continue
-        new_identifiers = set(device.identifiers)
-        new_identifiers.discard((DOMAIN, entry_id, old_uid))
-        new_identifiers.add((DOMAIN, entry_id, new_uid))
-        device_registry.async_update_device(device.id, new_identifiers=new_identifiers)
-        device_remapped_uids.add(old_uid)
+        planned_devices[old_uid] = device
 
-    applied = {
-        old_uid: old_to_new[old_uid]
-        for old_uid in entity_remapped_uids | device_remapped_uids
-    }
+    applied: dict[str, str] = {}
+    for old_uid, new_uid in old_to_new.items():
+        if old_uid in conflicted:
+            continue
+        entity_plans = planned_entities.get(old_uid, [])
+        device = planned_devices.get(old_uid)
+        if not entity_plans and device is None:
+            continue
+        for entry, new_unique_id in entity_plans:
+            entity_registry.async_update_entity(
+                entry.entity_id, new_unique_id=new_unique_id
+            )
+        if device is not None:
+            new_identifiers = set(device.identifiers)
+            new_identifiers.discard((DOMAIN, entry_id, old_uid))
+            new_identifiers.add((DOMAIN, entry_id, new_uid))
+            device_registry.async_update_device(
+                device.id, new_identifiers=new_identifiers
+            )
+        applied[old_uid] = new_uid
 
     runtime = runtime_from_hass(hass, entry_id)
     if runtime is not None and applied:

--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -16,5 +16,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.4b4"
+  "version": "1.2.4b5"
 }

--- a/custom_components/fritzbox_vpn/uid_identity.py
+++ b/custom_components/fritzbox_vpn/uid_identity.py
@@ -6,6 +6,13 @@ from typing import Any
 
 from fritzboxvpn import API_KEY_NAME
 
+from .const import UNIQUE_ID_PREFIX
+
+
+def entity_unique_id(connection_uid: str, suffix: str) -> str:
+    """Entity unique_id for a VPN connection and platform suffix (SSOT)."""
+    return f"{UNIQUE_ID_PREFIX}{connection_uid}_{suffix}"
+
 
 def name_bijection_uid_remap(
     old_uids: set[str],

--- a/docs/releases/v1.2.4b5.md
+++ b/docs/releases/v1.2.4b5.md
@@ -1,0 +1,15 @@
+## What's changed
+
+- **Fix:** Recovery stable-poll counting starts only after the minimum recovery window elapses (avoids clearing recovery one poll early).
+- **Fix:** UID remap records only pairs actually applied in the entity/device registry (partial conflicts no longer poison `_uid_remap` / `known_uids`).
+- **Fix:** Permanently empty VPN lists clear recovery after a hard max window so orphan tracking is not blocked forever.
+- **Hardening:** Shared `entity_unique_id` SSOT; toggle HTTPS+HTTP dual-fail regression test; options repair asserts merge outcome.
+
+### 🇩🇪 Deutsch
+
+- **Fix:** Stable-Poll-Zählung startet erst nach Ablauf des Minimum-Recovery-Fensters.
+- **Fix:** UID-Remap speichert nur tatsächlich akzeptierte Paare (Teilkonflikte vergiften `_uid_remap` / `known_uids` nicht).
+- **Fix:** Dauerhaft leere VPN-Listen beenden Recovery nach einem harten Maximum.
+- **Härten:** Gemeinsame `entity_unique_id`-SSOT; Toggle Dual-Fail-Test; Options-Repair prüft Merge-Ergebnis.
+
+**Full Changelog:** https://github.com/rosch100/fritzbox-vpn/compare/v1.2.4b4...v1.2.4b5

--- a/tests/test_config_flow_options.py
+++ b/tests/test_config_flow_options.py
@@ -197,11 +197,10 @@ async def test_options_repair_entity_ids_confirm(hass: HomeAssistant) -> None:
     assert result["type"] == FlowResultType.CREATE_ENTRY
 
 
-@pytest.mark.asyncio
 async def test_options_shows_repair_for_orphan_base_merge_only(
     hass: HomeAssistant,
 ) -> None:
-    """Repair action appears when only orphan-base+_2 merges are pending."""
+    """Repair merges orphan base+_2 and completes with base entity_id."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -242,16 +241,28 @@ async def test_options_shows_repair_for_orphan_base_merge_only(
         config_entry=entry,
     )
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "init"
+    with patch.object(hass.config_entries, "async_reload", new=AsyncMock()):
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "init"
 
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        {"action": OPTIONS_ACTION_REPAIR_ENTITY_IDS},
-    )
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "repair_entity_ids_confirm"
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {"action": OPTIONS_ACTION_REPAIR_ENTITY_IDS},
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "repair_entity_ids_confirm"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {"confirm": True},
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert registry.async_get("switch.office_vpn_2") is None
+    healed = registry.async_get("switch.office_vpn")
+    assert healed is not None
+    assert healed.unique_id == f"{UNIQUE_ID_PREFIX}vpn_new_switch"
 
 
 @pytest.mark.asyncio

--- a/tests/test_fritzconnection_session.py
+++ b/tests/test_fritzconnection_session.py
@@ -146,3 +146,28 @@ async def test_get_vpn_connections_https_and_http_fail_raises_connection_error()
     with pytest.raises(ConnectionError, match="failed to get login page"):
         await session.async_get_vpn_connections()
     assert session._use_tls is True
+
+
+@pytest.mark.asyncio
+async def test_toggle_vpn_https_and_http_fail_raises_connection_error() -> None:
+    """When HTTPS and HTTP both fail on toggle, raise ConnectionError."""
+    hass = MagicMock()
+    session = FritzConnectionVPNSession(hass, "1.2.3.4", "u", "p", use_tls=True)
+
+    def ensure() -> None:
+        raise RequestsConnectionError("down")
+
+    session._ensure_client = ensure  # type: ignore[method-assign]
+    session._close_sync = MagicMock()  # type: ignore[method-assign]
+    session._toggle_vpn_sync = MagicMock(  # type: ignore[method-assign]
+        side_effect=RequestsConnectionError("http down")
+    )
+
+    async def run_job(fn, *args):
+        return fn(*args)
+
+    hass.async_add_executor_job = AsyncMock(side_effect=run_job)
+
+    with pytest.raises(ConnectionError, match="failed to toggle VPN"):
+        await session.async_toggle_vpn("conn-abc", True)
+    assert session._use_tls is True

--- a/tests/test_fritzconnection_session.py
+++ b/tests/test_fritzconnection_session.py
@@ -153,14 +153,14 @@ async def test_toggle_vpn_https_and_http_fail_raises_connection_error() -> None:
     """When HTTPS and HTTP both fail on toggle, raise ConnectionError."""
     hass = MagicMock()
     session = FritzConnectionVPNSession(hass, "1.2.3.4", "u", "p", use_tls=True)
-
-    def ensure() -> None:
-        raise RequestsConnectionError("down")
-
-    session._ensure_client = ensure  # type: ignore[method-assign]
+    session._mode = "fritzconnection"
+    session._ensure_client = MagicMock()  # type: ignore[method-assign]
     session._close_sync = MagicMock()  # type: ignore[method-assign]
     session._toggle_vpn_sync = MagicMock(  # type: ignore[method-assign]
-        side_effect=RequestsConnectionError("http down")
+        side_effect=[
+            RequestsConnectionError("https down"),
+            RequestsConnectionError("http down"),
+        ]
     )
 
     async def run_job(fn, *args):
@@ -170,4 +170,6 @@ async def test_toggle_vpn_https_and_http_fail_raises_connection_error() -> None:
 
     with pytest.raises(ConnectionError, match="failed to toggle VPN"):
         await session.async_toggle_vpn("conn-abc", True)
+    assert session._toggle_vpn_sync.call_count == 2
+    session._close_sync.assert_called_once()
     assert session._use_tls is True

--- a/tests/test_reboot_recovery_entity_churn.py
+++ b/tests/test_reboot_recovery_entity_churn.py
@@ -11,6 +11,8 @@ from custom_components.fritzbox_vpn.const import (
     ORPHAN_CONFIRM_POLLS,
     RECOVERY_STABLE_POLLS,
     UNIQUE_ID_PREFIX,
+    UNIQUE_ID_SUFFIX_CONNECTED,
+    UNIQUE_ID_SUFFIX_STATUS,
     UNIQUE_ID_SUFFIX_SWITCH,
 )
 from custom_components.fritzbox_vpn.coordinator import (
@@ -564,20 +566,143 @@ async def test_uid_remap_records_only_applied_pairs(
     entry.runtime_data.known_uids_switch = set(old)
 
     registry = er.async_get(hass)
-    for uid in old:
+    device_registry = dr.async_get(hass)
+    for uid, payload in old.items():
         registry.async_get_or_create(
             "switch",
             DOMAIN,
             vpn_unique_id(uid, UNIQUE_ID_SUFFIX_SWITCH),
             config_entry=entry,
         )
-    # Conflict: target unique_id for new-def already exists under another entity.
+        registry.async_get_or_create(
+            "binary_sensor",
+            DOMAIN,
+            vpn_unique_id(uid, UNIQUE_ID_SUFFIX_CONNECTED),
+            config_entry=entry,
+        )
+        registry.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            vpn_unique_id(uid, UNIQUE_ID_SUFFIX_STATUS),
+            config_entry=entry,
+        )
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, entry.entry_id, uid)},
+            name=payload["name"],
+        )
+    # Full conflict: all platforms for new-def already exist.
     registry.async_get_or_create(
         "switch",
         DOMAIN,
         vpn_unique_id("new-def", UNIQUE_ID_SUFFIX_SWITCH),
         suggested_object_id="preexisting_guest",
         config_entry=entry,
+    )
+    # Partial conflict: old-abc switch remaps, but connected target already exists.
+    # Remap must refuse the whole UID (no partial platform/device apply).
+    registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        vpn_unique_id("new-abc", UNIQUE_ID_SUFFIX_CONNECTED),
+        suggested_object_id="preexisting_office_connected",
+        config_entry=entry,
+    )
+
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        side_effect=ConnectionError("refused")
+    )
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+    new = {
+        "new-abc": {
+            "uid": "new-abc",
+            "name": "Office VPN",
+            "active": True,
+            "connected": False,
+        },
+        "new-def": {
+            "uid": "new-def",
+            "name": "Guest VPN",
+            "active": False,
+            "connected": False,
+        },
+    }
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(return_value=new)
+    await coordinator._async_update_data()
+
+    assert "old-abc" not in coordinator._uid_remap
+    assert "old-def" not in coordinator._uid_remap
+    assert coordinator.resolve_connection_uid("old-abc") == "old-abc"
+    assert coordinator.resolve_connection_uid("old-def") == "old-def"
+    assert entry.runtime_data.known_uids_switch == {"old-abc", "old-def"}
+    assert registry.async_get_entity_id(
+        "switch", DOMAIN, vpn_unique_id("old-abc", UNIQUE_ID_SUFFIX_SWITCH)
+    )
+    assert device_registry.async_get_device(
+        identifiers={(DOMAIN, entry.entry_id, "old-abc")}
+    )
+
+
+@pytest.mark.asyncio
+async def test_uid_remap_applies_only_when_all_platforms_and_device_succeed(
+    hass: HomeAssistant,
+) -> None:
+    """Multi-platform + device remap applies only for fully successful UIDs."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": MOCK_HOST, "username": "u", "password": "p"},
+    )
+    entry.add_to_hass(hass)
+    entry.mock_state(hass, ConfigEntryState.LOADED)
+
+    coordinator = _coordinator(hass, entry)
+    old = {
+        "old-abc": {
+            "uid": "old-abc",
+            "name": "Office VPN",
+            "active": True,
+            "connected": False,
+        },
+        "old-def": {
+            "uid": "old-def",
+            "name": "Guest VPN",
+            "active": False,
+            "connected": False,
+        },
+    }
+    coordinator.async_set_updated_data(old)
+    coordinator._seen_uids = set(old)
+    coordinator._remember_connection_names(old)
+    entry.runtime_data = FritzboxVpnRuntimeData(coordinator=coordinator)
+    entry.runtime_data.known_uids_switch = set(old)
+
+    registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    for uid, payload in old.items():
+        registry.async_get_or_create(
+            "switch",
+            DOMAIN,
+            vpn_unique_id(uid, UNIQUE_ID_SUFFIX_SWITCH),
+            config_entry=entry,
+        )
+        registry.async_get_or_create(
+            "binary_sensor",
+            DOMAIN,
+            vpn_unique_id(uid, UNIQUE_ID_SUFFIX_CONNECTED),
+            config_entry=entry,
+        )
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, entry.entry_id, uid)},
+            name=payload["name"],
+        )
+    # Device conflict for old-def only; old-abc remaps fully.
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.entry_id, "new-def")},
+        name="Conflict Guest",
     )
 
     coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
@@ -605,5 +730,16 @@ async def test_uid_remap_records_only_applied_pairs(
 
     assert coordinator.resolve_connection_uid("old-abc") == "new-abc"
     assert "old-def" not in coordinator._uid_remap
-    assert coordinator.resolve_connection_uid("old-def") == "old-def"
     assert entry.runtime_data.known_uids_switch == {"new-abc", "old-def"}
+    assert registry.async_get_entity_id(
+        "switch", DOMAIN, vpn_unique_id("new-abc", UNIQUE_ID_SUFFIX_SWITCH)
+    )
+    assert registry.async_get_entity_id(
+        "binary_sensor", DOMAIN, vpn_unique_id("new-abc", UNIQUE_ID_SUFFIX_CONNECTED)
+    )
+    assert device_registry.async_get_device(
+        identifiers={(DOMAIN, entry.entry_id, "new-abc")}
+    )
+    assert device_registry.async_get_device(
+        identifiers={(DOMAIN, entry.entry_id, "old-def")}
+    )

--- a/tests/test_reboot_recovery_entity_churn.py
+++ b/tests/test_reboot_recovery_entity_churn.py
@@ -13,7 +13,10 @@ from custom_components.fritzbox_vpn.const import (
     UNIQUE_ID_PREFIX,
     UNIQUE_ID_SUFFIX_SWITCH,
 )
-from custom_components.fritzbox_vpn.coordinator import FritzBoxVPNCoordinator
+from custom_components.fritzbox_vpn.coordinator import (
+    FritzBoxVPNCoordinator,
+    recovery_max_seconds,
+)
 from custom_components.fritzbox_vpn.entity import (
     connection_available,
     setup_vpn_platform,
@@ -275,7 +278,17 @@ async def test_uid_remap_prevents_platform_readd(
     )
     assert len(add_calls) == 1
 
-    remap_connection_uids(hass, mock_config_entry.entry_id, {"old-abc": "new-abc"})
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        vpn_unique_id("old-abc", UNIQUE_ID_SUFFIX_SWITCH),
+        config_entry=mock_config_entry,
+    )
+    applied = remap_connection_uids(
+        hass, mock_config_entry.entry_id, {"old-abc": "new-abc"}
+    )
+    assert applied == {"old-abc": "new-abc"}
     assert mock_config_entry.runtime_data.known_uids_switch == {"new-abc"}
 
     coordinator.async_set_updated_data(
@@ -468,16 +481,129 @@ async def test_recovery_clears_after_window_and_stable_polls(
         await coordinator._async_update_data()
     assert coordinator._in_recovery()
 
-    # Time not elapsed yet: stable polls alone must not clear recovery.
+    # Time not elapsed yet: non-empty polls must not accumulate stable count.
     coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
         return_value=dict(MOCK_VPN_CONNECTIONS)
     )
     for _ in range(RECOVERY_STABLE_POLLS + 1):
         await coordinator._async_update_data()
     assert coordinator._in_recovery()
+    assert coordinator._recovery_stable_polls == 0
 
-    coordinator._recovering_until = 0  # window.monotonic() always >= 0
-    coordinator._recovery_stable_polls = 0
+    coordinator._recovering_until = 0  # time.monotonic() always >= 0
     for _ in range(RECOVERY_STABLE_POLLS):
         await coordinator._async_update_data()
     assert not coordinator._in_recovery()
+
+
+@pytest.mark.asyncio
+async def test_recovery_accepts_empty_after_max_duration(
+    hass: HomeAssistant,
+) -> None:
+    """Permanently empty VPN list clears recovery after the hard max window."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": MOCK_HOST, "username": "u", "password": "p"},
+    )
+    coordinator = _coordinator(hass, entry)
+    coordinator.async_set_updated_data(dict(MOCK_VPN_CONNECTIONS))
+    coordinator._seen_uids = set(MOCK_VPN_CONNECTIONS)
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        side_effect=ConnectionError("refused")
+    )
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+    assert coordinator._in_recovery()
+
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(return_value={})
+    with pytest.raises(UpdateFailed, match="empty while recovering"):
+        await coordinator._async_update_data()
+    assert coordinator._in_recovery()
+
+    max_seconds = recovery_max_seconds(coordinator._update_interval_seconds)
+    assert coordinator._recovery_started_at is not None
+    coordinator._recovery_started_at = (
+        coordinator._recovery_started_at - max_seconds - 1
+    )
+    result = await coordinator._async_update_data()
+    assert result == {}
+    assert not coordinator._in_recovery()
+
+
+@pytest.mark.asyncio
+async def test_uid_remap_records_only_applied_pairs(
+    hass: HomeAssistant,
+) -> None:
+    """Coordinator _uid_remap must omit pairs skipped by registry conflicts."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": MOCK_HOST, "username": "u", "password": "p"},
+    )
+    entry.add_to_hass(hass)
+    entry.mock_state(hass, ConfigEntryState.LOADED)
+
+    coordinator = _coordinator(hass, entry)
+    old = {
+        "old-abc": {
+            "uid": "old-abc",
+            "name": "Office VPN",
+            "active": True,
+            "connected": False,
+        },
+        "old-def": {
+            "uid": "old-def",
+            "name": "Guest VPN",
+            "active": False,
+            "connected": False,
+        },
+    }
+    coordinator.async_set_updated_data(old)
+    coordinator._seen_uids = set(old)
+    coordinator._remember_connection_names(old)
+    entry.runtime_data = FritzboxVpnRuntimeData(coordinator=coordinator)
+    entry.runtime_data.known_uids_switch = set(old)
+
+    registry = er.async_get(hass)
+    for uid in old:
+        registry.async_get_or_create(
+            "switch",
+            DOMAIN,
+            vpn_unique_id(uid, UNIQUE_ID_SUFFIX_SWITCH),
+            config_entry=entry,
+        )
+    # Conflict: target unique_id for new-def already exists under another entity.
+    registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        vpn_unique_id("new-def", UNIQUE_ID_SUFFIX_SWITCH),
+        suggested_object_id="preexisting_guest",
+        config_entry=entry,
+    )
+
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(
+        side_effect=ConnectionError("refused")
+    )
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+    new = {
+        "new-abc": {
+            "uid": "new-abc",
+            "name": "Office VPN",
+            "active": True,
+            "connected": False,
+        },
+        "new-def": {
+            "uid": "new-def",
+            "name": "Guest VPN",
+            "active": False,
+            "connected": False,
+        },
+    }
+    coordinator.fritz_session.async_get_vpn_connections = AsyncMock(return_value=new)
+    await coordinator._async_update_data()
+
+    assert coordinator.resolve_connection_uid("old-abc") == "new-abc"
+    assert "old-def" not in coordinator._uid_remap
+    assert coordinator.resolve_connection_uid("old-def") == "old-def"
+    assert entry.runtime_data.known_uids_switch == {"new-abc", "old-def"}


### PR DESCRIPTION
## Summary
- Count recovery stable polls only after the minimum recovery window elapses
- Record only registry-applied UID remaps in coordinator/`known_uids`
- Clear recovery after a hard max duration when the VPN list stays empty
- SSOT `entity_unique_id`, toggle dual-fail test, options merge assertions; bump to v1.2.4b5

## Test plan
- [x] `ruff check` + `ruff format`
- [x] `pytest tests/` (204 passed)
- [ ] CI green (Ruff, pytest, HACS, hassfest)
- [ ] CodeRabbit review finished without blocking findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved VPN recovery after router reboots by preventing indefinite retries and accepting persistently empty results after a capped recovery period.
  - Improved VPN entity identity updates with safer remapping and conflict handling.
  - VPN toggle failures now report connection errors consistently while preserving connection settings.
  - Improved repair flow handling for orphaned and duplicate VPN entities.

- **Documentation**
  - Added release notes covering recovery and entity remapping improvements.

- **Chores**
  - Updated the integration to version 1.2.4b5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->