### PR TITLE
fix: log FritzWireguard fallback at INFO (v1.2.4b6)

### DIFF
--- a/custom_components/fritzbox_vpn/const.py
+++ b/custom_components/fritzbox_vpn/const.py
@@ -87,8 +87,8 @@ LOG_MSG_UID_REMAP_REFUSED = (
     "(%s). added=%s removed=%s"
 )
 LOG_MSG_SESSION_MODE_FALLBACK = (
-    "FritzWireguard module unavailable; using fritzboxvpn web-API fallback "
-    "for host %s. Prefer installing a fritzconnection build with WireGuard support."
+    "FritzWireguard not in this fritzconnection build; using fritzboxvpn web-API "
+    "for host %s (expected fallback, not an error)."
 )
 LOG_MSG_ORPHAN_BASE_MERGE = (
     "Merged orphan base entity_id with live suffixed entity: %s → %s "

--- a/custom_components/fritzbox_vpn/fritzconnection_session.py
+++ b/custom_components/fritzbox_vpn/fritzconnection_session.py
@@ -89,7 +89,9 @@ class FritzConnectionVPNSession:
             self._mode = "fritzboxvpn"
             if not self._fallback_mode_logged:
                 self._fallback_mode_logged = True
-                _LOGGER.warning(LOG_MSG_SESSION_MODE_FALLBACK, self._host)
+                # INFO: HA surfaces custom-integration WARNINGs as red "errors".
+                # Missing FritzWireguard is an expected path, not a failure.
+                _LOGGER.info(LOG_MSG_SESSION_MODE_FALLBACK, self._host)
             return
 
         # Router API discovery happens here — callers must invoke this from a

--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -16,5 +16,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.4b5"
+  "version": "1.2.4b6"
 }

--- a/docs/releases/v1.2.4b6.md
+++ b/docs/releases/v1.2.4b6.md
@@ -1,0 +1,9 @@
+## What's changed
+
+- **Fix (#37 residual):** Expected FritzWireguard → fritzboxvpn web-API fallback is logged at INFO (not WARNING), so Home Assistant no longer surfaces it as a red custom-integration “error”.
+
+### 🇩🇪 Deutsch
+
+- **Fix (#37 Residual):** Erwarteter FritzWireguard → fritzboxvpn-Web-API-Fallback wird als INFO geloggt (nicht WARNING), damit Home Assistant ihn nicht mehr als roten Custom-Integration-„Fehler“ anzeigt.
+
+**Full Changelog:** https://github.com/rosch100/fritzbox-vpn/compare/v1.2.4b5...v1.2.4b6

--- a/tests/test_fritzconnection_session.py
+++ b/tests/test_fritzconnection_session.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from custom_components.fritzbox_vpn.const import LOG_MSG_SESSION_MODE_FALLBACK
 from custom_components.fritzbox_vpn.fritzconnection_session import (
     FritzConnectionVPNSession,
 )
@@ -77,6 +79,59 @@ def test_ensure_client_passes_timeout_to_fritzconnection() -> None:
         use_tls=True,
     )
     assert session._mode == "fritzconnection"
+
+
+def test_ensure_client_falls_back_to_fritzboxvpn_without_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Missing FritzWireguard uses web-API fallback and logs at INFO only."""
+    hass = MagicMock()
+    session = FritzConnectionVPNSession(hass, "192.168.20.1", "u", "p")
+    fake_fallback = MagicMock()
+    clientsession = MagicMock()
+
+    fc_mod = types.ModuleType("fritzconnection")
+    fc_mod.FritzConnection = MagicMock()
+    lib_mod = types.ModuleType("fritzconnection.lib")
+    lib_mod.__path__ = []  # type: ignore[attr-defined]
+
+    with (
+        patch.dict(
+            sys.modules,
+            {
+                "fritzconnection": fc_mod,
+                "fritzconnection.lib": lib_mod,
+                # None → import raises ModuleNotFoundError (PEP 302).
+                "fritzconnection.lib.fritzwireguard": None,
+            },
+        ),
+        patch(
+            "fritzboxvpn.FritzBoxVPNSession",
+            return_value=fake_fallback,
+        ) as fallback_cls,
+        patch(
+            "homeassistant.helpers.aiohttp_client.async_get_clientsession",
+            return_value=clientsession,
+        ),
+        caplog.at_level(logging.INFO),
+    ):
+        session._ensure_client()
+
+    assert session._mode == "fritzboxvpn"
+    assert session._fallback_session is fake_fallback
+    fallback_cls.assert_called_once_with(
+        clientsession,
+        "192.168.20.1",
+        "u",
+        "p",
+        protocol="https",
+    )
+    expected = LOG_MSG_SESSION_MODE_FALLBACK % "192.168.20.1"
+    assert expected in caplog.text
+    assert not any(
+        r.levelno >= logging.WARNING and expected in r.getMessage()
+        for r in caplog.records
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Expected FritzWireguard → fritzboxvpn web-API fallback is logged at **INFO** instead of WARNING, so Home Assistant no longer shows it as a red custom-integration “error” ([#37](https://github.com/rosch100/fritzbox-vpn/issues/37) residual / Bjoern3D feedback).
- Softened the log message; bump to **v1.2.4b6** with release notes.

## Test plan
- [x] `ruff check` + `ruff format --check`
- [x] `pytest tests/test_fritzconnection_session.py` (8 passed)
- [ ] CI green (Ruff, pytest, HACS, hassfest)
- [ ] After merge: tag `v1.2.4b6` to publish HACS beta
- [ ] Ask @Bjoern3D / @erkr to confirm the red log entry is gone on b6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated fallback messaging to clarify that using the web API when WireGuard support is unavailable is expected.
  * Reduced fallback log severity from Warning to Info to avoid unnecessary alerts.

* **Documentation**
  * Added release notes for version 1.2.4b6 in English and German.

* **Tests**
  * Added coverage confirming correct fallback selection, configuration handling, and logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->