### PR TITLE
fix: clarify Fritzconnection WireGuard fallback wording (v1.2.4b7)

### DIFF
--- a/custom_components/fritzbox_vpn/const.py
+++ b/custom_components/fritzbox_vpn/const.py
@@ -87,7 +87,7 @@ LOG_MSG_UID_REMAP_REFUSED = (
     "(%s). added=%s removed=%s"
 )
 LOG_MSG_SESSION_MODE_FALLBACK = (
-    "FritzWireguard not in this fritzconnection build; using fritzboxvpn web-API "
+    "Fritzconnection WireGuard support unavailable; using fritzboxvpn web-API "
     "for host %s (expected fallback, not an error)."
 )
 LOG_MSG_ORPHAN_BASE_MERGE = (

--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -16,5 +16,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.4b6"
+  "version": "1.2.4b7"
 }

--- a/docs/releases/v1.2.4b7.md
+++ b/docs/releases/v1.2.4b7.md
@@ -1,0 +1,9 @@
+## What's changed
+
+- **Fix:** Clarify session fallback log wording so it covers any missing Fritzconnection WireGuard support (package or module), not only a missing WireGuard build.
+
+### 🇩🇪 Deutsch
+
+- **Fix:** Fallback-Log klarer formuliert — gilt für fehlende Fritzconnection-WireGuard-Unterstützung (Paket oder Modul), nicht nur für ein fehlendes WireGuard-Build.
+
+**Full Changelog:** https://github.com/rosch100/fritzbox-vpn/compare/v1.2.4b6...v1.2.4b7


### PR DESCRIPTION
## Summary
- CodeRabbit follow-up to [#52](https://github.com/rosch100/fritzbox-vpn/pull/52): broaden `LOG_MSG_SESSION_MODE_FALLBACK` so it covers any missing Fritzconnection WireGuard support (package or module), not only a missing WireGuard build.
- Bump to **v1.2.4b7** with release notes.

## Test plan
- [x] `pytest tests/test_fritzconnection_session.py`
- [x] `ruff check` on touched Python
- [ ] CI green
- [ ] After merge: tag `v1.2.4b7`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the WireGuard fallback message to clearly indicate when Fritzconnection WireGuard support is unavailable, including package or module absence.

- **Documentation**
  - Added release notes for version 1.2.4b7, including German-language notes and a link to the full changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->