### PR TITLE
docs: Fritz!Box reboot recovery and correct retry timing

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -72,7 +72,21 @@ Du kannst das Update-Intervall (wie oft die Integration den VPN-Status prüft) i
 
 Das Update-Intervall legt fest, wie oft die Integration die FritzBox abfragt. Niedrigere Werte = häufigere Updates, höhere Werte (bis 3600 s = 1 h) reduzieren Reconnects und Last.
 
-**Reconnects und Last reduzieren:** Die Integration nutzt Session-Caching (ein Login pro Ladevorgang) und bei Abfragefehlern einen 60‑Sekunden-Backoff vor dem nächsten Versuch (damit Fritz!Box-Reboots ohne manuelles Reload wieder verfügbar werden). Für noch weniger Reconnects und FritzBox-Last das Update-Intervall auf 300 Sekunden (5 Min) oder höher setzen; Maximum ist 3600 (1 h).
+**Reconnects und Last reduzieren:** Die Integration nutzt Session-Caching (ein Login pro Ladevorgang) und bei Abfragefehlern einen **60‑Sekunden**-Backoff vor dem nächsten Versuch (damit Fritz!Box-Reboots ohne manuelles Reload wieder verfügbar werden). Für noch weniger Reconnects und FritzBox-Last das Update-Intervall auf 300 Sekunden (5 Min) oder höher setzen; Maximum ist 3600 (1 h).
+
+### Fritz!Box-Reboot und Verbindungsausfälle
+
+Nach einem Router-Reboot oder längerem Ausschalten solltest du die Integration **nicht** manuell neu laden müssen. Entitäten können unavailable bleiben, solange die Box nicht erreichbar ist, und danach von selbst zurückkommen.
+
+**Ablauf:**
+
+1. Beim **ersten fehlgeschlagenen Verbindungsversuch** zur Fritz!Box startet ein Recovery-Fenster (mindestens **180 Sekunden** bei Standardeinstellungen; länger, wenn das Update-Intervall über 60 s liegt). Jeder weitere Fehlversuch kann das Fenster **verlängern**.
+2. Während der Recovery gilt eine vorübergehend leere oder unvollständige VPN-Liste **nicht** als „Verbindungen gelöscht“. So entstehen keine verwaisten Entitäten und keine `_2`/`_3`-Duplikate.
+3. Sobald die Box wieder erreichbar ist und die VPN-Namen zu den bisherigen passen, werden geänderte Connection-UIDs **an Ort und Stelle remappt** (gleiche Geräte/Entitäten).
+4. Erst wenn das Mindestfenster vorbei ist **und** einige stabile, nicht-leere Abfragen gelungen sind, läuft die Orphan-Bereinigung wieder. Eine wirklich auf der Box gelöschte VPN wird erst nach mehreren fehlenden Polls bestätigt.
+5. Bleibt die VPN-Liste lange leer, obwohl die Box wieder antwortet (Harte Obergrenze: etwa **das Doppelte** des Mindest-Recovery-Fensters), endet die Recovery, damit nichts ewig hängen bleibt. Mehrstündiger Stromausfall ist unproblematisch: Recovery bleibt während des Ausfalls aktiv; Remapping läuft, wenn die Box zurück ist.
+
+Logzeilen wie „recovery window armed“ oder „UID remapped after outage recovery“ sind erwartet. Eine spätere Meldung „no longer available“ zu **alten** UIDs nach einem Remap betrifft die ersetzten IDs, keine neuen Duplikate.
 
 ### Optionen und Dienste
 
@@ -193,8 +207,10 @@ Unter **Einstellungen → Geräte & Dienste → Fritz!Box VPN → ⋮ → Diagno
 | **Authentifizierung fehlgeschlagen** | Zugangsdaten; TR-064 aktiv; **Erneut anmelden**, wenn angeboten |
 | **Verbindung fehlgeschlagen** | IP/Hostname; Erreichbarkeit von HA; ggf. HTTP statt HTTPS |
 | **Keine VPN-Entitäten** | WireGuard auf der Fritz!Box eingerichtet; Integration neu laden |
-| **Entitäten unavailable** | VPN auf der Box gelöscht – **Unavailable-Entitäten entfernen** in den Optionen |
-| **Entitäts-IDs mit `_2`** | **Entitäts-ID-Suffixe reparieren** in den Optionen |
+| **Entitäten unavailable nach Fritz!Box-Reboot** | 1–3 Minuten warten, nachdem die Box wieder da ist; **nicht** sofort neu laden. Siehe [Fritz!Box-Reboot und Verbindungsausfälle](#fritzbox-reboot-und-verbindungsausfälle) |
+| **Entitäten unavailable (VPN auf der Box gelöscht)** | **Unavailable-Entitäten entfernen** in den Optionen |
+| **Entitäts-IDs mit `_2`** | Nach einem Reboot zuerst auf automatische Recovery warten; sonst **Entitäts-ID-Suffixe reparieren** in den Optionen |
+| **Log: Fritzconnection WireGuard support unavailable** | Nur Info: die Integration nutzt den Web-API-Pfad. Kein Fehler |
 
 ## Deinstallation
 

--- a/README.de.md
+++ b/README.de.md
@@ -82,7 +82,7 @@ Nach einem Router-Reboot oder längerem Ausschalten solltest du die Integration 
 
 1. Beim **ersten fehlgeschlagenen Verbindungsversuch** zur Fritz!Box startet ein Recovery-Fenster (mindestens **180 Sekunden** bei Standardeinstellungen; länger, wenn das Update-Intervall über 60 s liegt). Jeder weitere Fehlversuch kann das Fenster **verlängern**.
 2. Während der Recovery gilt eine vorübergehend leere oder unvollständige VPN-Liste **nicht** als „Verbindungen gelöscht“. So entstehen keine verwaisten Entitäten und keine `_2`/`_3`-Duplikate.
-3. Sobald die Box wieder erreichbar ist und die VPN-Namen zu den bisherigen passen, werden geänderte Connection-UIDs **an Ort und Stelle remappt** (gleiche Geräte/Entitäten).
+3. Sobald die Box wieder erreichbar ist und die VPN-Namen zu den bisherigen **eindeutig (1:1)** passen, werden geänderte Connection-UIDs **an Ort und Stelle remappt** (gleiche Geräte/Entitäten).
 4. Erst wenn das Mindestfenster vorbei ist **und** einige stabile, nicht-leere Abfragen gelungen sind, läuft die Orphan-Bereinigung wieder. Eine wirklich auf der Box gelöschte VPN wird erst nach mehreren fehlenden Polls bestätigt.
 5. Bleibt die VPN-Liste lange leer, obwohl die Box wieder antwortet (Harte Obergrenze: etwa **das Doppelte** des Mindest-Recovery-Fensters), endet die Recovery, damit nichts ewig hängen bleibt. Mehrstündiger Stromausfall ist unproblematisch: Recovery bleibt während des Ausfalls aktiv; Remapping läuft, wenn die Box zurück ist.
 
@@ -207,7 +207,7 @@ Unter **Einstellungen → Geräte & Dienste → Fritz!Box VPN → ⋮ → Diagno
 | **Authentifizierung fehlgeschlagen** | Zugangsdaten; TR-064 aktiv; **Erneut anmelden**, wenn angeboten |
 | **Verbindung fehlgeschlagen** | IP/Hostname; Erreichbarkeit von HA; ggf. HTTP statt HTTPS |
 | **Keine VPN-Entitäten** | WireGuard auf der Fritz!Box eingerichtet; Integration neu laden |
-| **Entitäten unavailable nach Fritz!Box-Reboot** | 1–3 Minuten warten, nachdem die Box wieder da ist; **nicht** sofort neu laden. Siehe [Fritz!Box-Reboot und Verbindungsausfälle](#fritzbox-reboot-und-verbindungsausfälle) |
+| **Entitäten unavailable nach Fritz!Box-Reboot** | Beim Standard-Update-Intervall 1–3 Minuten warten, nachdem die Box wieder da ist (bei größerem Intervall ggf. länger); **nicht** sofort neu laden. Siehe [Fritz!Box-Reboot und Verbindungsausfälle](#fritzbox-reboot-und-verbindungsausfälle) |
 | **Entitäten unavailable (VPN auf der Box gelöscht)** | **Unavailable-Entitäten entfernen** in den Optionen |
 | **Entitäts-IDs mit `_2`** | Nach einem Reboot zuerst auf automatische Recovery warten; sonst **Entitäts-ID-Suffixe reparieren** in den Optionen |
 | **Log: Fritzconnection WireGuard support unavailable** | Nur Info: die Integration nutzt den Web-API-Pfad. Kein Fehler |

--- a/README.md
+++ b/README.md
@@ -72,7 +72,21 @@ You can configure the update interval (how often the integration checks for VPN 
 
 The update interval determines how frequently the integration polls the FritzBox for VPN status updates. Lower values give more frequent updates; higher values (e.g. 300–3600 s) reduce reconnects. You can set up to 1 hour (3600 s) for minimal load.
 
-**Reducing reconnects and load:** The integration uses session caching (one login per load) and, on fetch errors, a 60‑second backoff before retrying (so Fritz!Box reboots recover without a manual reload). To further reduce reconnects and FritzBox load, set the update interval to 300 seconds (5 min) or higher; maximum is 3600 (1 h).
+**Reducing reconnects and load:** The integration uses session caching (one login per load) and, on fetch errors, a **60‑second** backoff before retrying (so Fritz!Box reboots recover without a manual reload). To further reduce reconnects and FritzBox load, set the update interval to 300 seconds (5 min) or higher; maximum is 3600 (1 h).
+
+### Fritz!Box reboot and connectivity outages
+
+After a router reboot or longer power-off, you should **not** need to reload the integration. Entities may stay unavailable while the box is unreachable, then come back on their own.
+
+**What happens:**
+
+1. On the **first failed connection** to the Fritz!Box, a recovery window starts (at least **180 seconds** with the default settings; longer if your update interval is above 60 s). Each further failed poll can **extend** that window.
+2. While recovery is active, a temporarily empty or incomplete VPN list is **not** treated as “connections deleted”. That avoids orphaned entities and `_2` / `_3` duplicates.
+3. When the box is reachable again and VPN names match the previous ones, connection UIDs that changed after reboot are **remapped** in place (same devices/entities).
+4. Only after the minimum window has elapsed **and** a few stable non-empty polls succeed does orphan cleanup resume. A VPN that was really removed on the box is confirmed only after several consecutive misses.
+5. If the VPN list stays empty for a long time after the box answers again (hard cap: about **twice** the minimum recovery window), recovery ends so cleanup cannot hang forever. A multi-hour power-off is fine: recovery stays active for the outage; remapping runs when the box returns.
+
+You may see log lines such as “recovery window armed” or “UID remapped after outage recovery”. That is expected. A later “no longer available” line for **old** UIDs after a remap refers to the replaced IDs, not new duplicates.
 
 ### Options and services
 
@@ -193,8 +207,10 @@ Under **Settings → Devices & Services → Fritz!Box VPN → ⋮ → Download d
 | **Invalid authentication** | Username/password; TR-064 enabled; complete **Reauthenticate** flow when prompted |
 | **Cannot connect** | Correct IP/hostname; HA can reach the Fritz!Box; try HTTP if HTTPS fails |
 | **No VPN entities** | WireGuard connections configured on the Fritz!Box; reload integration |
-| **Entities unavailable** | VPN removed on router – use **Remove unavailable entities** in options |
-| **Entity IDs with `_2` suffix** | Use **Repair entity ID suffixes** in options |
+| **Entities unavailable after Fritz!Box reboot** | Wait 1–3 minutes after the box is back; do **not** reload immediately. See [Fritz!Box reboot and connectivity outages](#fritzbox-reboot-and-connectivity-outages) |
+| **Entities unavailable (VPN deleted on router)** | Use **Remove unavailable entities** in options |
+| **Entity IDs with `_2` suffix** | Prefer waiting for automatic recovery after a reboot; otherwise use **Repair entity ID suffixes** in options |
+| **Log: Fritzconnection WireGuard support unavailable** | Info only: the integration uses its web-API path. Not an error |
 
 ## Removal
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ After a router reboot or longer power-off, you should **not** need to reload the
 
 1. On the **first failed connection** to the Fritz!Box, a recovery window starts (at least **180 seconds** with the default settings; longer if your update interval is above 60 s). Each further failed poll can **extend** that window.
 2. While recovery is active, a temporarily empty or incomplete VPN list is **not** treated as “connections deleted”. That avoids orphaned entities and `_2` / `_3` duplicates.
-3. When the box is reachable again and VPN names match the previous ones, connection UIDs that changed after reboot are **remapped** in place (same devices/entities).
+3. When the box is reachable again and VPN names match the previous ones **uniquely (1:1)**, connection UIDs that changed after reboot are **remapped** in place (same devices/entities).
 4. Only after the minimum window has elapsed **and** a few stable non-empty polls succeed does orphan cleanup resume. A VPN that was really removed on the box is confirmed only after several consecutive misses.
 5. If the VPN list stays empty for a long time after the box answers again (hard cap: about **twice** the minimum recovery window), recovery ends so cleanup cannot hang forever. A multi-hour power-off is fine: recovery stays active for the outage; remapping runs when the box returns.
 
@@ -207,7 +207,7 @@ Under **Settings → Devices & Services → Fritz!Box VPN → ⋮ → Download d
 | **Invalid authentication** | Username/password; TR-064 enabled; complete **Reauthenticate** flow when prompted |
 | **Cannot connect** | Correct IP/hostname; HA can reach the Fritz!Box; try HTTP if HTTPS fails |
 | **No VPN entities** | WireGuard connections configured on the Fritz!Box; reload integration |
-| **Entities unavailable after Fritz!Box reboot** | Wait 1–3 minutes after the box is back; do **not** reload immediately. See [Fritz!Box reboot and connectivity outages](#fritzbox-reboot-and-connectivity-outages) |
+| **Entities unavailable after Fritz!Box reboot** | With the default update interval, wait 1–3 minutes after the box is back (longer if you configured a larger interval); do **not** reload immediately. See [Fritz!Box reboot and connectivity outages](#fritzbox-reboot-and-connectivity-outages) |
 | **Entities unavailable (VPN deleted on router)** | Use **Remove unavailable entities** in options |
 | **Entity IDs with `_2` suffix** | Prefer waiting for automatic recovery after a reboot; otherwise use **Repair entity ID suffixes** in options |
 | **Log: Fritzconnection WireGuard support unavailable** | Info only: the integration uses its web-API path. Not an error |

--- a/docs/home-assistant-io/fritzbox_vpn.markdown
+++ b/docs/home-assistant-io/fritzbox_vpn.markdown
@@ -111,7 +111,7 @@ While recovery is active:
 
 - A temporarily empty or incomplete VPN list is treated as an outage, not as deleted connections
 - Orphan cleanup is paused so entities are not removed and `_2` / `_3` duplicates are not created
-- When the router returns and VPN **names** still match, changed connection UIDs are **remapped** onto the existing devices and entities
+- When the router returns and VPN **names** match uniquely **(1:1)**, changed connection UIDs are **remapped** onto the existing devices and entities
 
 Recovery ends after the minimum window has elapsed and a few stable non-empty polls succeed. A connection that was really removed on the router is confirmed only after several consecutive misses. If the VPN list stays empty long after the box answers again (about twice the minimum recovery window), recovery clears so cleanup cannot hang forever. Long maintenance power-offs are supported the same way: wait for the box to return; no manual reload is required.
 
@@ -177,9 +177,10 @@ Repairs entity IDs that received a numeric suffix after faulty deactivation (for
 | **Invalid authentication** | Username and password; TR-064 enabled; complete **Reauthenticate** when prompted |
 | **Cannot connect** | Correct IP or hostname; Home Assistant can reach the FRITZ!Box; HTTPS vs HTTP |
 | **No VPN entities** | WireGuard connections configured in the FRITZ!Box UI; reload the integration |
-| **Entities unavailable after FRITZ!Box reboot** | Wait 1–3 minutes after the box is back; do not reload immediately — see [Connectivity outages and FRITZ!Box reboot](#connectivity-outages-and-fritzbox-reboot) |
+| **Entities unavailable after FRITZ!Box reboot** | With the default update interval, wait 1–3 minutes after the box is back (longer if you configured a larger interval); do not reload immediately — see [Connectivity outages and FRITZ!Box reboot](#connectivity-outages-and-fritzbox-reboot) |
 | **Entities unavailable (VPN deleted on router)** | Use **Remove unavailable entities** in options |
 | **Entity IDs with `_2` suffix** | After a reboot, wait for automatic recovery; otherwise use **Repair entity ID suffixes** in options |
+| **Log: Fritzconnection WireGuard support unavailable** | Info only: the integration uses its web-API path. Not an error |
 
 Enable debug logging from the integration card (**⋮** → **Enable debug logging**), reproduce the issue, then disable debug logging to download logs.
 

--- a/docs/home-assistant-io/fritzbox_vpn.markdown
+++ b/docs/home-assistant-io/fritzbox_vpn.markdown
@@ -101,7 +101,19 @@ Switch attributes include `name`, `uid`, `vpn_uid`, `active`, `connected`, and `
 
 ## Data updates
 
-The integration polls the FRITZ!Box web UI on a configurable interval (default **30 seconds**, range 5–3600 seconds). After repeated fetch errors, retries are delayed by **5 minutes**. A single login session is reused per config entry to minimize router notifications.
+The integration polls the FRITZ!Box web UI on a configurable interval (default **30 seconds**, range 5–3600 seconds). After a fetch error (for example while the router reboots), the next retry is delayed by **60 seconds**. A single login session is reused per config entry to minimize router notifications.
+
+### Connectivity outages and FRITZ!Box reboot
+
+When Home Assistant cannot reach the FRITZ!Box, a **recovery window** starts on the first failed connection (at least **180 seconds** with default settings; longer if the update interval is above 60 seconds). Failed polls during the outage can extend that window.
+
+While recovery is active:
+
+- A temporarily empty or incomplete VPN list is treated as an outage, not as deleted connections
+- Orphan cleanup is paused so entities are not removed and `_2` / `_3` duplicates are not created
+- When the router returns and VPN **names** still match, changed connection UIDs are **remapped** onto the existing devices and entities
+
+Recovery ends after the minimum window has elapsed and a few stable non-empty polls succeed. A connection that was really removed on the router is confirmed only after several consecutive misses. If the VPN list stays empty long after the box answers again (about twice the minimum recovery window), recovery clears so cleanup cannot hang forever. Long maintenance power-offs are supported the same way: wait for the box to return; no manual reload is required.
 
 ## Use cases
 
@@ -165,8 +177,9 @@ Repairs entity IDs that received a numeric suffix after faulty deactivation (for
 | **Invalid authentication** | Username and password; TR-064 enabled; complete **Reauthenticate** when prompted |
 | **Cannot connect** | Correct IP or hostname; Home Assistant can reach the FRITZ!Box; HTTPS vs HTTP |
 | **No VPN entities** | WireGuard connections configured in the FRITZ!Box UI; reload the integration |
-| **Entities unavailable** | VPN removed on the router — use **Remove unavailable entities** in options |
-| **Entity IDs with `_2` suffix** | Use **Repair entity ID suffixes** in options |
+| **Entities unavailable after FRITZ!Box reboot** | Wait 1–3 minutes after the box is back; do not reload immediately — see [Connectivity outages and FRITZ!Box reboot](#connectivity-outages-and-fritzbox-reboot) |
+| **Entities unavailable (VPN deleted on router)** | Use **Remove unavailable entities** in options |
+| **Entity IDs with `_2` suffix** | After a reboot, wait for automatic recovery; otherwise use **Repair entity ID suffixes** in options |
 
 Enable debug logging from the integration card (**⋮** → **Enable debug logging**), reproduce the issue, then disable debug logging to download logs.
 


### PR DESCRIPTION
## Summary
- Document connectivity outage / Fritz!Box reboot recovery in **README.md**, **README.de.md**, and the home-assistant.io draft (when the window starts, UID remap, long power-off, expected logs).
- Fix outdated “5 minute” retry in the HA.io draft to the implemented **60 s** backoff.
- Expand troubleshooting for reboot unavailability vs deleted VPNs, and the WireGuard fallback info log.

## Test plan
- [x] Numbers match `const.py` / `coordinator.py` (`RETRY_AFTER=60`, min recovery ≥180 s at default interval, max empty ≈2× min window)
- [ ] Skim EN/DE README for consistency
- [ ] CI green (docs-only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on recovery after Fritz!Box reboots and connection outages.
  * Documented retry delays, recovery windows, UID remapping, and delayed cleanup of orphaned entities.
  * Expanded troubleshooting information for unavailable entities, deleted VPN connections, suffixed entity IDs, and informational WireGuard logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->