### PR TITLE
chore: release v1.2.4

### DIFF
--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -16,5 +16,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.4b7"
+  "version": "1.2.4"
 }

--- a/docs/releases/v1.2.4.md
+++ b/docs/releases/v1.2.4.md
@@ -1,0 +1,17 @@
+## What's changed (since v1.2.3)
+
+- **Fix (#42 / #37):** After a Fritz!Box reboot or connectivity outage, VPN entities recover automatically — no integration reload and no `_2` entity/device churn.
+- **Recovery:** Empty VPN lists during the recovery window are treated as outage (not as deleted connections). Name-stable UID changes are remapped in the entity/device registry; orphan confirmation is paused until recovery completes.
+- **Repair:** Orphan base entity + live `_2` pairs can be merged on setup and via Options/Service repair.
+- **Session:** FritzConnection adapter with constructor timeout; expected missing-FritzWireguard path uses the fritzboxvpn web API and is logged at INFO (not as a red custom-integration “error”).
+- **Docs:** README (EN/DE) and HA.io draft document the recovery window, retry timing (60 s), UID remap, and troubleshooting.
+
+### 🇩🇪 Was ist neu (seit v1.2.3)
+
+- **Fix (#42 / #37):** Nach Fritz!Box-Reboot oder Verbindungsausfall erholen sich VPN-Entities automatisch — ohne Reload und ohne `_2`-Entity-/Device-Churn.
+- **Recovery:** Leere VPN-Listen im Recovery-Fenster gelten als Outage (nicht als gelöschte Verbindungen). Namensgleiche UID-Wechsel werden in Entity-/Device-Registry remappt; Orphan-Bestätigung pausiert bis Recovery-Ende.
+- **Repair:** Orphan-Base + live-`_2`-Paare lassen sich beim Setup und über Options/Service Repair mergen.
+- **Session:** FritzConnection-Adapter mit Constructor-Timeout; erwarteter Pfad ohne FritzWireguard nutzt die fritzboxvpn-Web-API und wird als INFO geloggt (kein roter Custom-Integration-„Fehler“).
+- **Doku:** README (EN/DE) und HA.io-Entwurf beschreiben Recovery-Fenster, Retry (60 s), UID-Remap und Troubleshooting.
+
+**Full Changelog:** https://github.com/rosch100/fritzbox-vpn/compare/v1.2.3...v1.2.4


### PR DESCRIPTION
## Summary
- Bump integration version from `1.2.4b7` → **`1.2.4`** (stable).
- Add `docs/releases/v1.2.4.md` summarizing reboot recovery (#37/#42), UID remap, session fallback, and docs from the beta series.

## Test plan
- [x] `manifest.json` version is `1.2.4`
- [ ] CI green
- [ ] After merge: tag `v1.2.4` → Release workflow publishes HACS stable release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VPN connections now recover automatically after Fritz!Box outages.
  * Empty connection lists during outages are handled without incorrectly removing entities.
  * Orphaned entities are repaired, and changed connection identifiers are remapped.

* **Bug Fixes**
  * Improved Fritz!Box session handling and logging behavior.

* **Documentation**
  * Added English and German release notes for version 1.2.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->