### PR TITLE
Fix FRITZ!OS 8.40 VPN listing (v1.2.5b1)

### DIFF
--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -10,11 +10,11 @@
   "issue_tracker": "https://github.com/rosch100/fritzbox-vpn/issues",
   "loggers": ["fritzboxvpn"],
   "quality_scale": "gold",
-  "requirements": ["fritzboxvpn==1.0.2", "fritzconnection"],
+  "requirements": ["fritzboxvpn==1.0.3", "fritzconnection"],
   "ssdp": [
     {
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.4"
+  "version": "1.2.5b1"
 }

--- a/docs/releases/v1.2.5b1.md
+++ b/docs/releases/v1.2.5b1.md
@@ -1,0 +1,11 @@
+## What's changed
+
+- **Fix (#56):** FRITZ!OS 8.40 Labor compatibility — WireGuard listing no longer depends on the removed `data.lua` / `shareWireguard` / `boxConnections` payload. The library uses `GET /api/v0/generic/vpn` when the legacy page omits `boxConnections`, while older FRITZ!OS versions keep the `data.lua` path.
+- **Library:** Requires `fritzboxvpn==1.0.3`.
+
+### 🇩🇪 Deutsch
+
+- **Fix (#56):** Kompatibilität mit FRITZ!OS 8.40 Labor — WireGuard-Listing hängt nicht mehr am entfernten `data.lua`-/`shareWireguard`-/`boxConnections`-Payload. Die Library nutzt `GET /api/v0/generic/vpn`, wenn die Legacy-Seite `boxConnections` nicht liefert; ältere FRITZ!OS-Versionen behalten den `data.lua`-Pfad.
+- **Library:** Benötigt `fritzboxvpn==1.0.3`.
+
+**Full Changelog:** https://github.com/rosch100/fritzbox-vpn/compare/v1.2.4...v1.2.5b1

--- a/fritzboxvpn/fritzboxvpn/__init__.py
+++ b/fritzboxvpn/fritzboxvpn/__init__.py
@@ -3,6 +3,7 @@
 from .const import API_KEY_ACTIVE, API_KEY_CONNECTED, API_KEY_NAME, API_KEY_UID
 from .parsing import (
     extract_box_connections_from_data,
+    extract_wireguard_connections_from_rest,
     normalize_box_connections,
     parse_blocktime_from_login_xml,
     parse_challenge_from_login_xml,
@@ -17,6 +18,7 @@ __all__ = [
     "API_KEY_UID",
     "FritzBoxVPNSession",
     "extract_box_connections_from_data",
+    "extract_wireguard_connections_from_rest",
     "normalize_box_connections",
     "parse_blocktime_from_login_xml",
     "parse_challenge_from_login_xml",

--- a/fritzboxvpn/fritzboxvpn/const.py
+++ b/fritzboxvpn/fritzboxvpn/const.py
@@ -2,17 +2,31 @@
 
 API_LOGIN = "/login_sid.lua"
 API_DATA = "/data.lua"
-API_VPN_CONNECTION = "/api/v0/generic/vpn/connection/{uid}"
+API_VPN_ROOT = "/api/v0/generic/vpn"
+API_VPN_CONNECTION = f"{API_VPN_ROOT}/connection/{{uid}}"
 
 API_PAGE_SHAREWIREGUARD = "shareWireguard"
 API_KEY_DATA = "data"
 API_KEY_INIT = "init"
 API_KEY_BOX_CONNECTIONS = "boxConnections"
+API_KEY_CONNECTION = "connection"
 API_KEY_UID = "uid"
+API_KEY_UID_REST = "UID"
 API_KEY_ACTIVE = "active"
 API_KEY_ACTIVATED = "activated"
 API_KEY_CONNECTED = "connected"
+API_KEY_CONNECTED_SINCE = "connected_since"
+API_KEY_STATE = "state"
 API_KEY_NAME = "name"
+API_KEY_ACCESS_TYPE = "access_type"
+ACCESS_TYPE_WIREGUARD = "4"
+WIREGUARD_STATE_READY = "ready"
+HEADER_CLIENT_NAME = "Client-Name"
+HEADER_VALUE_CLIENT_NAME = "WebGUI"
+LISTING_MODE_DATA_LUA = "data_lua"
+LISTING_MODE_REST = "rest"
+# Prefer legacy data.lua, then FRITZ!OS 8.40+ REST listing.
+LISTING_PROBE_ORDER = (LISTING_MODE_DATA_LUA, LISTING_MODE_REST)
 
 DEFAULT_TIMEOUT = 10
 DEFAULT_PROTOCOL = "https"
@@ -25,7 +39,8 @@ CONTENT_TYPE_JSON = "json"
 
 HTTP_STATUS_OK = 200
 HTTP_STATUS_FORBIDDEN = 403
-HTTPS_FALLBACK_STATUS_CODES = (400, 404, 502, 503)
+HTTP_STATUS_NOT_FOUND = 404
+HTTPS_FALLBACK_STATUS_CODES = (400, HTTP_STATUS_NOT_FOUND, 502, 503)
 
 LOGIN_TAG_CHALLENGE = "Challenge"
 LOGIN_TAG_SID = "SID"
@@ -46,6 +61,9 @@ DEFAULT_NAME_UNKNOWN = "Unknown"
 ERROR_MSG_INVALID_SID = "Invalid SID"
 ERROR_MSG_INVALID_SID_403 = "Invalid SID (HTTP 403)"
 ERROR_MSG_INVALID_SID_HTML = "Invalid SID (HTML response)"
+ERROR_MSG_VPN_PAYLOAD_MISSING = (
+    "VPN connections payload missing from Fritz!Box response"
+)
 ERROR_MSG_LOGIN_FAILED_SID = (
     "Login failed: Invalid SID. This can be caused by: "
     "(1) Incorrect username or password, or "

--- a/fritzboxvpn/fritzboxvpn/parsing.py
+++ b/fritzboxvpn/fritzboxvpn/parsing.py
@@ -7,16 +7,25 @@ import xml.etree.ElementTree as ET
 from typing import Any
 
 from .const import (
+    ACCESS_TYPE_WIREGUARD,
     ACTIVE_STATE_STRINGS_TRUE,
+    API_KEY_ACCESS_TYPE,
     API_KEY_ACTIVATED,
     API_KEY_ACTIVE,
     API_KEY_BOX_CONNECTIONS,
+    API_KEY_CONNECTED,
+    API_KEY_CONNECTED_SINCE,
+    API_KEY_CONNECTION,
     API_KEY_DATA,
     API_KEY_INIT,
+    API_KEY_NAME,
+    API_KEY_STATE,
     API_KEY_UID,
+    API_KEY_UID_REST,
     LOGIN_TAG_BLOCKTIME,
     LOGIN_TAG_CHALLENGE,
     LOGIN_TAG_SID,
+    WIREGUARD_STATE_READY,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -188,3 +197,68 @@ def extract_box_connections_from_data(data: dict[str, Any], page: str) -> Any:
         },
     )
     return None
+
+
+def _connection_connected_from_rest(conn: dict[str, Any]) -> bool:
+    """Connected flag from FRITZ!OS 8.40 REST connection fields."""
+    state = conn.get(API_KEY_STATE)
+    if isinstance(state, str) and state.strip() == WIREGUARD_STATE_READY:
+        return True
+    raw_since = conn.get(API_KEY_CONNECTED_SINCE)
+    if raw_since is None:
+        return False
+    try:
+        return int(raw_since) != 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _rest_wireguard_entry(conn: dict[str, Any]) -> dict[str, Any] | None:
+    """Map one REST connection to the shared boxConnections entry shape."""
+    access_type = conn.get(API_KEY_ACCESS_TYPE)
+    if str(access_type).strip() != ACCESS_TYPE_WIREGUARD:
+        return None
+    uid = conn.get(API_KEY_UID)
+    if uid is None:
+        uid = conn.get(API_KEY_UID_REST)
+    activated = conn.get(API_KEY_ACTIVATED)
+    return {
+        API_KEY_UID: uid,
+        API_KEY_NAME: conn.get(API_KEY_NAME),
+        API_KEY_ACTIVATED: activated,
+        API_KEY_ACTIVE: conn.get(API_KEY_ACTIVE, activated),
+        API_KEY_CONNECTED: _connection_connected_from_rest(conn),
+    }
+
+
+def extract_wireguard_connections_from_rest(
+    data: dict[str, Any],
+) -> list[dict[str, Any]] | None:
+    """Extract WireGuard connections from GET /api/v0/generic/vpn JSON.
+
+    Returns None when the REST listing contract is absent. An empty list means
+    the endpoint answered with zero WireGuard connections.
+    """
+    if not isinstance(data, dict):
+        return None
+    raw_connections = data.get(API_KEY_CONNECTION)
+    if raw_connections is None:
+        _LOGGER.debug(
+            "Could not extract connection list from REST VPN JSON. structure summary=%s",
+            {
+                "data_keys": list(data.keys())[:50],
+                "connection": describe_json_value(data.get(API_KEY_CONNECTION)),
+            },
+        )
+        return None
+    if not isinstance(raw_connections, list):
+        return None
+
+    result: list[dict[str, Any]] = []
+    for conn in raw_connections:
+        if not isinstance(conn, dict):
+            continue
+        entry = _rest_wireguard_entry(conn)
+        if entry is not None:
+            result.append(entry)
+    return result

--- a/fritzboxvpn/fritzboxvpn/session.py
+++ b/fritzboxvpn/fritzboxvpn/session.py
@@ -9,7 +9,13 @@ import logging
 from typing import Any, NoReturn
 from urllib.parse import urlsplit
 
-from aiohttp import ClientConnectorError, ClientSession, ClientTimeout
+from aiohttp import (
+    ClientConnectorError,
+    ClientResponse,
+    ClientSession,
+    ClientTimeout,
+    hdrs,
+)
 
 from .const import (
     API_DATA,
@@ -20,6 +26,7 @@ from .const import (
     API_LOGIN,
     API_PAGE_SHAREWIREGUARD,
     API_VPN_CONNECTION,
+    API_VPN_ROOT,
     AUTH_HEADER_PREFIX,
     CONTENT_TYPE_JSON,
     DEFAULT_NAME_UNKNOWN,
@@ -29,11 +36,18 @@ from .const import (
     ERROR_MSG_INVALID_SID_403,
     ERROR_MSG_INVALID_SID_HTML,
     ERROR_MSG_LOGIN_FAILED_SID,
+    ERROR_MSG_VPN_PAYLOAD_MISSING,
+    HEADER_CLIENT_NAME,
     HEADER_VALUE_APPLICATION_JSON,
+    HEADER_VALUE_CLIENT_NAME,
     HTTP_STATUS_FORBIDDEN,
+    HTTP_STATUS_NOT_FOUND,
     HTTP_STATUS_OK,
     HTTPS_FALLBACK_STATUS_CODES,
     INVALID_SID_VALUE,
+    LISTING_MODE_DATA_LUA,
+    LISTING_MODE_REST,
+    LISTING_PROBE_ORDER,
     LOG_LABEL_ACTIVATED,
     LOG_LABEL_DEACTIVATED,
     LOGIN_FORM_RESPONSE,
@@ -46,6 +60,7 @@ from .const import (
 )
 from .parsing import (
     extract_box_connections_from_data,
+    extract_wireguard_connections_from_rest,
     normalize_box_connections,
     parse_blocktime_from_login_xml,
     parse_challenge_from_login_xml,
@@ -72,6 +87,68 @@ class FritzBoxVPNSession:
         self.password = password
         self.protocol = protocol if protocol in PROTOCOLS_ALLOWED else DEFAULT_PROTOCOL
         self.sid: str | None = None
+        self._listing_mode: str | None = None
+
+    def _base_url(self) -> str:
+        """Protocol + host origin for REST URLs and browser-like headers."""
+        return f"{self.protocol}://{self.host}"
+
+    def _login_url(self, *, version2: bool = False) -> str:
+        """login_sid.lua URL; optionally FRITZ!OS version=2 (PBKDF2)."""
+        url = f"{self._base_url()}{API_LOGIN}"
+        if version2:
+            return f"{url}?version=2"
+        return url
+
+    def _rest_headers(self, sid: str, *, mutation: bool = False) -> dict[str, str]:
+        """Headers required by FRITZ!OS REST helpers (AVM-SID + WebGUI client)."""
+        headers = {
+            hdrs.AUTHORIZATION: f"{AUTH_HEADER_PREFIX}{sid}",
+            hdrs.CONTENT_TYPE: HEADER_VALUE_APPLICATION_JSON,
+            hdrs.ACCEPT: HEADER_VALUE_APPLICATION_JSON,
+            HEADER_CLIENT_NAME: HEADER_VALUE_CLIENT_NAME,
+        }
+        if mutation:
+            base = self._base_url()
+            headers[hdrs.ACCEPT] = "*/*"
+            headers[hdrs.ORIGIN] = base
+            headers[hdrs.REFERER] = f"{base}/"
+        return headers
+
+    @staticmethod
+    async def _response_json_dict(
+        response: ClientResponse, *, require_json: bool = False
+    ) -> dict[str, Any] | None:
+        """Parse response body as a JSON object; None when contract is absent."""
+        content_type = (response.headers.get(hdrs.CONTENT_TYPE) or "").lower()
+        if CONTENT_TYPE_JSON not in content_type:
+            if require_json:
+                raise ValueError(ERROR_MSG_INVALID_SID_HTML)
+            return None
+        try:
+            data = json.loads(await response.text())
+        except (json.JSONDecodeError, TypeError) as err:
+            if require_json:
+                raise ValueError(ERROR_MSG_INVALID_SID_HTML) from err
+            return None
+        if isinstance(data, dict):
+            return data
+        return None
+
+    def _validate_vpn_listing_status(
+        self,
+        response: ClientResponse,
+        *,
+        source: str,
+    ) -> None:
+        """Validate a successful listing response or raise its explicit error."""
+        if response.status == HTTP_STATUS_FORBIDDEN:
+            raise ValueError(ERROR_MSG_INVALID_SID_403)
+        if response.status != HTTP_STATUS_OK:
+            self.invalidate_session()
+            raise ConnectionError(
+                f"Failed to get VPN connections{source}: HTTP {response.status}"
+            )
 
     async def async_get_session(self) -> tuple[ClientSession, str]:
         """Return session and SID; reuse cached SID if valid."""
@@ -98,7 +175,7 @@ class FritzBoxVPNSession:
                 "falling back to MD5."
             )
 
-        login_url = f"{self.protocol}://{self.host}{API_LOGIN}"
+        login_url = self._login_url()
         try:
             content = await self._fetch_login_page(login_url, timeout)
         except (ConnectionError, ValueError) as err:
@@ -125,7 +202,7 @@ class FritzBoxVPNSession:
             LOGIN_FORM_RESPONSE: f"{challenge}-{response_hash}",
         }
         # Rebuild after possible HTTPS→HTTP fallback in _fetch_login_page.
-        login_url = f"{self.protocol}://{self.host}{API_LOGIN}"
+        login_url = self._login_url()
         try:
             async with self.session.post(
                 login_url, data=login_data, ssl=False, timeout=timeout
@@ -149,8 +226,7 @@ class FritzBoxVPNSession:
     async def _try_get_session_via_pbkdf2(self, timeout: ClientTimeout) -> str | None:
         """Return valid SID via pbkdf2 challenge-response, or None if unsupported."""
         _LOGGER.debug("Trying PBKDF2 login flow (login_sid.lua?version=2).")
-        login_url_get = f"{self.protocol}://{self.host}{API_LOGIN}?version=2"
-        content = await self._fetch_login_page(login_url_get, timeout)
+        content = await self._fetch_login_page(self._login_url(version2=True), timeout)
         if not content:
             return None
 
@@ -172,10 +248,12 @@ class FritzBoxVPNSession:
             LOGIN_FORM_RESPONSE: response,
         }
 
-        login_url_post = f"{self.protocol}://{self.host}{API_LOGIN}?version=2"
         try:
             async with self.session.post(
-                login_url_post, data=login_data, ssl=False, timeout=timeout
+                self._login_url(version2=True),
+                data=login_data,
+                ssl=False,
+                timeout=timeout,
             ) as response_http:
                 if response_http.status != HTTP_STATUS_OK:
                     return None
@@ -273,10 +351,45 @@ class FritzBoxVPNSession:
             )
             return await self._get_login_page_http(api_path, query, timeout)
 
-    async def _fetch_vpn_connections_once(self) -> dict[str, Any]:
-        """Single VPN connections request; raises on outage/missing payload."""
-        session, sid = await self.async_get_session()
-        data_url = f"{self.protocol}://{self.host}{API_DATA}"
+    async def _fetch_listing_by_mode(
+        self, mode: str, session: ClientSession, sid: str
+    ) -> dict[str, Any] | None:
+        """Dispatch to the listing implementation for a cached/probed mode."""
+        if mode == LISTING_MODE_REST:
+            return await self._fetch_vpn_connections_via_rest(session, sid)
+        if mode == LISTING_MODE_DATA_LUA:
+            return await self._fetch_vpn_connections_via_data_lua(session, sid)
+        raise ValueError(f"Unknown VPN listing mode: {mode}")
+
+    async def _fetch_vpn_connections_via_rest(
+        self, session: ClientSession, sid: str
+    ) -> dict[str, Any] | None:
+        """GET /api/v0/generic/vpn; None when the REST listing contract is absent."""
+        timeout = ClientTimeout(total=DEFAULT_TIMEOUT)
+        try:
+            async with session.get(
+                f"{self._base_url()}{API_VPN_ROOT}",
+                headers=self._rest_headers(sid),
+                timeout=timeout,
+                ssl=False,
+            ) as response:
+                if response.status == HTTP_STATUS_NOT_FOUND:
+                    return None
+                self._validate_vpn_listing_status(response, source=" via REST")
+                data = await self._response_json_dict(response)
+                if data is None:
+                    return None
+                box = extract_wireguard_connections_from_rest(data)
+                if box is None:
+                    return None
+                return normalize_box_connections(box)
+        except (ClientConnectorError, OSError) as err:
+            self._raise_transport_error(err)
+
+    async def _fetch_vpn_connections_via_data_lua(
+        self, session: ClientSession, sid: str
+    ) -> dict[str, Any] | None:
+        """POST /data.lua shareWireguard; None when boxConnections is absent."""
         params = {
             "sid": sid,
             "xhr": "1",
@@ -287,39 +400,46 @@ class FritzBoxVPNSession:
         timeout = ClientTimeout(total=DEFAULT_TIMEOUT)
         try:
             async with session.post(
-                data_url, data=params, timeout=timeout, ssl=False
+                f"{self._base_url()}{API_DATA}",
+                data=params,
+                timeout=timeout,
+                ssl=False,
             ) as response:
-                if response.status == HTTP_STATUS_FORBIDDEN:
-                    raise ValueError(ERROR_MSG_INVALID_SID_403)
-                if response.status != HTTP_STATUS_OK:
-                    self.invalidate_session()
-                    raise ConnectionError(
-                        f"Failed to get VPN connections: HTTP {response.status}"
-                    )
-
-                content_type = (response.headers.get("Content-Type") or "").lower()
-                if CONTENT_TYPE_JSON not in content_type:
-                    raise ValueError(ERROR_MSG_INVALID_SID_HTML)
-                try:
-                    body = await response.text()
-                    data = json.loads(body)
-                except (json.JSONDecodeError, TypeError) as err:
-                    raise ValueError(ERROR_MSG_INVALID_SID_HTML) from err
-
+                self._validate_vpn_listing_status(response, source="")
+                data = await self._response_json_dict(response, require_json=True)
+                if data is None:
+                    return None
                 box = extract_box_connections_from_data(data, API_PAGE_SHAREWIREGUARD)
-                if box is not None:
-                    return normalize_box_connections(box)
-                # Missing boxConnections is typical while the box is rebooting or the
-                # cached SID/protocol is stale — do not soft-succeed with {}.
-                self.invalidate_session()
-                raise ConnectionError(
-                    "VPN connections payload missing from Fritz!Box response"
-                )
-        except ConnectionError:
-            raise
+                if box is None:
+                    return None
+                return normalize_box_connections(box)
         except (ClientConnectorError, OSError) as err:
             # Reboot / port-down: clear cached SID+protocol so the next poll recovers.
             self._raise_transport_error(err)
+
+    async def _fetch_vpn_connections_once(self) -> dict[str, Any]:
+        """Single VPN connections request; raises on outage/missing payload."""
+        session, sid = await self.async_get_session()
+        preferred = self._listing_mode
+
+        if preferred is not None:
+            result = await self._fetch_listing_by_mode(preferred, session, sid)
+            if result is not None:
+                return result
+            self._listing_mode = None
+
+        for mode in LISTING_PROBE_ORDER:
+            if mode == preferred:
+                continue
+            result = await self._fetch_listing_by_mode(mode, session, sid)
+            if result is not None:
+                self._listing_mode = mode
+                return result
+
+        # Missing payloads are typical while the box is rebooting or the
+        # cached SID/protocol is stale — do not soft-succeed with {}.
+        self.invalidate_session()
+        raise ConnectionError(ERROR_MSG_VPN_PAYLOAD_MISSING)
 
     async def async_get_vpn_connections(self) -> dict[str, Any]:
         """WireGuard VPN connections; cached session, retry once on SID expiry."""
@@ -363,15 +483,8 @@ class FritzBoxVPNSession:
             return True
 
         session, sid = await self.async_get_session()
-        base = f"{self.protocol}://{self.host}"
-        api_url = f"{base}{API_VPN_CONNECTION.format(uid=vpn_uid)}"
-        headers = {
-            "Content-Type": HEADER_VALUE_APPLICATION_JSON,
-            "Authorization": f"{AUTH_HEADER_PREFIX}{sid}",
-            "Accept": "*/*",
-            "Origin": base,
-            "Referer": f"{base}/",
-        }
+        api_url = f"{self._base_url()}{API_VPN_CONNECTION.format(uid=vpn_uid)}"
+        headers = self._rest_headers(sid, mutation=True)
         request_body = {API_KEY_ACTIVATED: 1 if enable else 0}
 
         timeout = ClientTimeout(total=DEFAULT_TIMEOUT)
@@ -433,9 +546,11 @@ class FritzBoxVPNSession:
 
         Protocol is reset to HTTPS because a temporary reboot outage can flip
         HTTPS→HTTP permanently for the lifetime of this session object.
+        Listing mode is cleared so a firmware/API change is rediscovered.
         """
         self.sid = None
         self.protocol = DEFAULT_PROTOCOL
+        self._listing_mode = None
 
     async def async_close(self) -> None:
         """Clear cached SID and reset protocol."""

--- a/fritzboxvpn/pyproject.toml
+++ b/fritzboxvpn/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fritzboxvpn"
-version = "1.0.2"
+version = "1.0.3"
 description = "Async Python library for AVM Fritz!Box WireGuard VPN (Web UI / data.lua API)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,4 +1,4 @@
-"""Shared test data for FritzBox VPN tests."""
+"""Shared external-contract test data for FritzBox VPN tests."""
 
 MOCK_HOST = "192.168.178.1"
 MOCK_USERNAME = "ha-user"
@@ -42,4 +42,35 @@ MOCK_DATA_LUA_JSON = {
             }
         }
     }
+}
+
+# FRITZ!OS 8.40+ REST listing (GET /api/v0/generic/vpn).
+# Derived from Labor firmware 8.40-135099 (5690 Pro) Web UI.
+MOCK_REST_VPN_JSON = {
+    "connection": [
+        {
+            "UID": "conn-abc",
+            "name": "Office VPN",
+            "activated": "1",
+            "access_type": "4",
+            "state": "ready",
+            "connected_since": "1710000000",
+        },
+        {
+            "UID": "ipsec-1",
+            "name": "IPSec Peer",
+            "activated": "1",
+            "access_type": "1",
+            "state": "ready",
+            "connected_since": "1710000000",
+        },
+        {
+            "UID": "conn-def",
+            "name": "Guest VPN",
+            "activated": "0",
+            "access_type": "4",
+            "state": "notActive",
+            "connected_since": "0",
+        },
+    ]
 }

--- a/tests/test_coordinator_parsing.py
+++ b/tests/test_coordinator_parsing.py
@@ -2,14 +2,27 @@
 
 from custom_components.fritzbox_vpn.coordinator import _resolve_update_interval_seconds
 from fritzboxvpn import FritzBoxVPNSession
+from fritzboxvpn.const import (
+    API_KEY_ACTIVE,
+    API_KEY_CONNECTED,
+    API_KEY_NAME,
+    API_PAGE_SHAREWIREGUARD,
+)
 from fritzboxvpn.parsing import (
     extract_box_connections_from_data,
+    extract_wireguard_connections_from_rest,
+    normalize_box_connections,
     parse_blocktime_from_login_xml,
     parse_challenge_from_login_xml,
     parse_sid_from_login_response,
 )
 
-from tests.fixtures import LOGIN_XML_CHALLENGE, LOGIN_XML_SID, MOCK_DATA_LUA_JSON
+from tests.fixtures import (
+    LOGIN_XML_CHALLENGE,
+    LOGIN_XML_SID,
+    MOCK_DATA_LUA_JSON,
+    MOCK_REST_VPN_JSON,
+)
 
 
 def test_parse_login_xml() -> None:
@@ -21,9 +34,31 @@ def test_parse_login_xml() -> None:
 
 def test_extract_box_connections() -> None:
     """Extract boxConnections from data.lua JSON."""
-    box = extract_box_connections_from_data(MOCK_DATA_LUA_JSON, "shareWireguard")
+    box = extract_box_connections_from_data(
+        MOCK_DATA_LUA_JSON, API_PAGE_SHAREWIREGUARD
+    )
     assert box is not None
     assert "conn-abc" in box
+
+
+def test_extract_wireguard_connections_from_rest_fritzos_840() -> None:
+    """FRITZ!OS 8.40 REST payload yields only WireGuard connections."""
+    box = extract_wireguard_connections_from_rest(MOCK_REST_VPN_JSON)
+    assert box is not None
+    connections = normalize_box_connections(box)
+    assert set(connections) == {"conn-abc", "conn-def"}
+    assert connections["conn-abc"][API_KEY_NAME] == "Office VPN"
+    assert connections["conn-abc"][API_KEY_ACTIVE] is True
+    assert connections["conn-abc"][API_KEY_CONNECTED] is True
+    assert connections["conn-def"][API_KEY_ACTIVE] is False
+    assert connections["conn-def"][API_KEY_CONNECTED] is False
+    assert "ipsec-1" not in connections
+
+
+def test_extract_wireguard_connections_from_rest_missing_payload() -> None:
+    """Missing connection list is an explicit miss, not an empty success."""
+    assert extract_wireguard_connections_from_rest({"other": []}) is None
+    assert extract_wireguard_connections_from_rest({}) is None
 
 
 def test_resolve_update_interval() -> None:

--- a/tests/test_coordinator_parsing.py
+++ b/tests/test_coordinator_parsing.py
@@ -34,9 +34,7 @@ def test_parse_login_xml() -> None:
 
 def test_extract_box_connections() -> None:
     """Extract boxConnections from data.lua JSON."""
-    box = extract_box_connections_from_data(
-        MOCK_DATA_LUA_JSON, API_PAGE_SHAREWIREGUARD
-    )
+    box = extract_box_connections_from_data(MOCK_DATA_LUA_JSON, API_PAGE_SHAREWIREGUARD)
     assert box is not None
     assert "conn-abc" in box
 

--- a/tests/test_coordinator_session.py
+++ b/tests/test_coordinator_session.py
@@ -3,7 +3,15 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from aiohttp import hdrs
 from fritzboxvpn import FritzBoxVPNSession
+from fritzboxvpn.const import (
+    API_DATA,
+    API_VPN_ROOT,
+    AUTH_HEADER_PREFIX,
+    HEADER_CLIENT_NAME,
+    HEADER_VALUE_CLIENT_NAME,
+)
 
 from tests.aiohttp_mock import MockAiohttpResponse, QueuedAiohttpSession, json_response
 from tests.fixtures import (
@@ -12,6 +20,7 @@ from tests.fixtures import (
     MOCK_DATA_LUA_JSON,
     MOCK_HOST,
     MOCK_PASSWORD,
+    MOCK_REST_VPN_JSON,
     MOCK_USERNAME,
 )
 
@@ -225,3 +234,54 @@ async def test_pbkdf2_login_when_supported() -> None:
     connections = await fb.async_get_vpn_connections()
     assert "conn-abc" in connections
     assert any("version=2" in url for _, url, _ in http.requests)
+
+
+@pytest.mark.asyncio
+async def test_session_fritzos_840_rest_listing_after_data_lua_miss() -> None:
+    """FRITZ!OS 8.40: data.lua without boxConnections falls back to REST listing."""
+    data_lua_without_box = {"data": {"init": {"pageTitle": "VPN"}}}
+    http = QueuedAiohttpSession(
+        [
+            *_login_sequence(),
+            json_response(data_lua_without_box),
+            json_response(MOCK_REST_VPN_JSON),
+        ]
+    )
+    fb = FritzBoxVPNSession(http, MOCK_HOST, MOCK_USERNAME, MOCK_PASSWORD)
+    connections = await fb.async_get_vpn_connections()
+    assert set(connections) == {"conn-abc", "conn-def"}
+    assert connections["conn-abc"]["active"] is True
+    assert connections["conn-abc"]["connected"] is True
+
+    rest_gets = [
+        (method, url, kwargs)
+        for method, url, kwargs in http.requests
+        if method == "GET" and API_VPN_ROOT in url
+    ]
+    assert len(rest_gets) == 1
+    headers = rest_gets[0][2].get("headers") or {}
+    assert headers.get(hdrs.AUTHORIZATION) == f"{AUTH_HEADER_PREFIX}deadbeef"
+    assert headers.get(HEADER_CLIENT_NAME) == HEADER_VALUE_CLIENT_NAME
+
+
+@pytest.mark.asyncio
+async def test_session_fritzos_840_rest_mode_skips_data_lua_on_next_poll() -> None:
+    """After REST listing succeeds once, subsequent polls use REST only."""
+    data_lua_without_box = {"data": {"init": {"pageTitle": "VPN"}}}
+    http = QueuedAiohttpSession(
+        [
+            *_login_sequence(),
+            json_response(data_lua_without_box),
+            json_response(MOCK_REST_VPN_JSON),
+            json_response(MOCK_REST_VPN_JSON),
+        ]
+    )
+    fb = FritzBoxVPNSession(http, MOCK_HOST, MOCK_USERNAME, MOCK_PASSWORD)
+    assert "conn-abc" in await fb.async_get_vpn_connections()
+    assert "conn-abc" in await fb.async_get_vpn_connections()
+    data_lua_posts = [
+        url
+        for method, url, _ in http.requests
+        if method == "POST" and url.endswith(API_DATA)
+    ]
+    assert len(data_lua_posts) == 1

--- a/tests/test_session_reboot_recovery.py
+++ b/tests/test_session_reboot_recovery.py
@@ -139,11 +139,12 @@ async def test_coordinator_login_failed_still_schedules_reauth(hass) -> None:
 
 @pytest.mark.asyncio
 async def test_missing_box_connections_invalidates_and_raises() -> None:
-    """JSON without boxConnections is treated as outage, not empty success."""
+    """JSON without boxConnections/REST listing is treated as outage, not empty success."""
     http = QueuedAiohttpSession(
         [
             *_login_sequence(),
             json_response({"data": {"init": {"other": True}}}),
+            MockAiohttpResponse(404, text="not found"),
         ]
     )
     fb = FritzBoxVPNSession(http, MOCK_HOST, MOCK_USERNAME, MOCK_PASSWORD)


### PR DESCRIPTION
## Summary
- support the FRITZ!OS 8.40 VPN REST listing when the legacy WireGuard payload is absent
- retain the legacy `data.lua` path for older firmware and cache the detected listing mode
- release HACS beta `v1.2.5b1` with `fritzboxvpn==1.0.3`

## Test plan
- [x] Ruff (`custom_components`, `tests`, `fritzboxvpn`)
- [x] Full pytest suite: 210 passed
- [x] Coverage: 91.59% (minimum 85%)
- [x] Build wheel and sdist; validate with Twine

Related to #56; keep open until reporter validation on FRITZ!OS 8.40.