### PR TITLE
Release v1.2.5

### DIFF
--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -1,20 +1,29 @@
 {
   "domain": "fritzbox_vpn",
   "name": "Fritz!Box VPN",
-  "codeowners": ["@rosch100"],
+  "codeowners": [
+    "@rosch100"
+  ],
   "config_flow": true,
-  "dependencies": ["ssdp"],
+  "dependencies": [
+    "ssdp"
+  ],
   "documentation": "https://github.com/rosch100/fritzbox-vpn",
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/rosch100/fritzbox-vpn/issues",
-  "loggers": ["fritzboxvpn"],
+  "loggers": [
+    "fritzboxvpn"
+  ],
   "quality_scale": "gold",
-  "requirements": ["fritzboxvpn==1.0.3", "fritzconnection"],
+  "requirements": [
+    "fritzboxvpn==1.0.3",
+    "fritzconnection"
+  ],
   "ssdp": [
     {
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.5b1"
+  "version": "1.2.5"
 }

--- a/docs/releases/v1.2.5.md
+++ b/docs/releases/v1.2.5.md
@@ -1,0 +1,11 @@
+## What's changed (since v1.2.4)
+
+- **Fix (#56):** FRITZ!OS 8.40 Labor compatibility — WireGuard listing no longer depends on the removed `data.lua` / `shareWireguard` / `boxConnections` payload. The library uses `GET /api/v0/generic/vpn` when the legacy page omits `boxConnections`, while older FRITZ!OS versions keep the `data.lua` path.
+- **Library:** Requires `fritzboxvpn==1.0.3`.
+
+### 🇩🇪 Was ist neu (seit v1.2.4)
+
+- **Fix (#56):** Kompatibilität mit FRITZ!OS 8.40 Labor — WireGuard-Listing hängt nicht mehr am entfernten `data.lua`-/`shareWireguard`-/`boxConnections`-Payload. Die Library nutzt `GET /api/v0/generic/vpn`, wenn die Legacy-Seite `boxConnections` nicht liefert; ältere FRITZ!OS-Versionen behalten den `data.lua`-Pfad.
+- **Library:** Benötigt `fritzboxvpn==1.0.3`.
+
+**Full Changelog:** https://github.com/rosch100/fritzbox-vpn/compare/v1.2.4...v1.2.5


### PR DESCRIPTION
## Summary
- promote beta `v1.2.5b1` to stable `v1.2.5`
- keep `fritzboxvpn==1.0.3` (already published)
- add release notes for the FRITZ!OS 8.40 fix (#56)

## Test plan
- [x] Reporter confirmed beta works on FRITZ!OS 8.40 (`Working again`)
- [ ] CI (Ruff, pytest, HACS validate, hassfest)

Closes #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added compatibility with FRITZ!OS 8.40 Labor.
  - Added a fallback method for retrieving VPN data when legacy connection data is unavailable.
  - Preserved support for older FRITZ!OS versions.

- **Documentation**
  - Added release notes for version 1.2.5 in English and German.
  - Documented updated VPN data handling and the complete changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->