### PR TITLE
Release v1.2.6

### DIFF
--- a/custom_components/fritzbox_vpn/manifest.json
+++ b/custom_components/fritzbox_vpn/manifest.json
@@ -25,5 +25,5 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "version": "1.2.5"
+  "version": "1.2.6"
 }

--- a/docs/releases/v1.2.6.md
+++ b/docs/releases/v1.2.6.md
@@ -1,0 +1,9 @@
+## What's changed (since v1.2.5)
+
+- **Maintenance (#59):** Test/CI Home Assistant pin raised to `2026.8.2` (Python 3.14) so Dependabot alerts CVE-2026-64825 and CVE-2026-54317 are closed. Runtime integration behavior is unchanged.
+
+### 🇩🇪 Was ist neu (seit v1.2.5)
+
+- **Wartung (#59):** Test-/CI-Pin für Home Assistant auf `2026.8.2` (Python 3.14) angehoben, damit die Dependabot-Alerts CVE-2026-64825 und CVE-2026-54317 geschlossen sind. Das Laufzeitverhalten der Integration ist unverändert.
+
+**Full Changelog:** https://github.com/rosch100/fritzbox-vpn/compare/v1.2.5...v1.2.6


### PR DESCRIPTION
## Summary
- bump integration version to `1.2.6`
- add HACS/HA release notes for the #59 test/CI Home Assistant 2026.8.2 pin (CVE-2026-64825, CVE-2026-54317)
- no runtime behavior change

## Test plan
- [ ] CI grün (`CI` / `Ruff`, `pytest`, `HACS validate`, `hassfest`)
- [ ] Nach Merge: Tag `v1.2.6` erzeugt GitHub Release